### PR TITLE
Darcy rayner/fix metric timestamps

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -87,9 +87,9 @@ func DistributionWithContext(ctx context.Context, metric string, value float64, 
 	m := metrics.Distribution{
 		Name:   metric,
 		Tags:   tags,
-		Values: []float64{},
+		Values: []metrics.MetricValue{},
 	}
-	m.AddPoint(value)
+	m.AddPoint(time.Now(), value)
 	pr.AddMetric(&m)
 }
 

--- a/internal/metrics/batcher_test.go
+++ b/internal/metrics/batcher_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -21,19 +21,19 @@ func TestGetMetricDifferentTagOrder(t *testing.T) {
 	batcher := MakeBatcher(10)
 	dm1 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{1, 2},
+		Values: []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}},
 		Tags:   []string{"a", "b", "c"},
 	}
 	dm2 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{3, 4},
+		Values: []MetricValue{{Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}},
 		Tags:   []string{"c", "b", "a"},
 	}
 
-	batcher.AddMetric(tm, &dm1)
-	batcher.AddMetric(tm, &dm2)
+	batcher.AddMetric(&dm1)
+	batcher.AddMetric(&dm2)
 
-	assert.Equal(t, []float64{1, 2, 3, 4}, dm1.Values)
+	assert.Equal(t, []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}, {Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}}, dm1.Values)
 }
 
 func TestGetMetricFailDifferentName(t *testing.T) {
@@ -43,19 +43,19 @@ func TestGetMetricFailDifferentName(t *testing.T) {
 
 	dm1 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{1, 2},
+		Values: []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}},
 		Tags:   []string{"a", "b", "c"},
 	}
 	dm2 := Distribution{
 		Name:   "metric-2",
-		Values: []float64{3, 4},
+		Values: []MetricValue{{Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}},
 		Tags:   []string{"c", "b", "a"},
 	}
 
-	batcher.AddMetric(tm, &dm1)
-	batcher.AddMetric(tm, &dm2)
+	batcher.AddMetric(&dm1)
+	batcher.AddMetric(&dm2)
 
-	assert.Equal(t, []float64{1, 2}, dm1.Values)
+	assert.Equal(t, []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}}, dm1.Values)
 
 }
 
@@ -67,22 +67,22 @@ func TestGetMetricFailDifferentHost(t *testing.T) {
 	host2 := "my-host-2"
 
 	dm1 := Distribution{
-		Name:   "metric-1",
-		Values: []float64{1, 2},
-		Tags:   []string{"a", "b", "c"},
-		Host:   &host1,
+		Values: []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}},
+
+		Tags: []string{"a", "b", "c"},
+		Host: &host1,
 	}
 	dm2 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{3, 4},
+		Values: []MetricValue{{Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}},
 		Tags:   []string{"a", "b", "c"},
 		Host:   &host2,
 	}
 
-	batcher.AddMetric(tm, &dm1)
-	batcher.AddMetric(tm, &dm2)
+	batcher.AddMetric(&dm1)
+	batcher.AddMetric(&dm2)
 
-	assert.Equal(t, []float64{1, 2}, dm1.Values)
+	assert.Equal(t, []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}}, dm1.Values)
 }
 
 func TestGetMetricSameHost(t *testing.T) {
@@ -94,21 +94,21 @@ func TestGetMetricSameHost(t *testing.T) {
 
 	dm1 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{1, 2},
+		Values: []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}},
 		Tags:   []string{"a", "b", "c"},
 		Host:   &host,
 	}
 	dm2 := Distribution{
 		Name:   "metric-1",
-		Values: []float64{3, 4},
+		Values: []MetricValue{{Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}},
 		Tags:   []string{"a", "b", "c"},
 		Host:   &host,
 	}
 
-	batcher.AddMetric(tm, &dm1)
-	batcher.AddMetric(tm, &dm2)
+	batcher.AddMetric(&dm1)
+	batcher.AddMetric(&dm2)
 
-	assert.Equal(t, []float64{1, 2, 3, 4}, dm1.Values)
+	assert.Equal(t, []MetricValue{{Timestamp: tm, Value: 1}, {Timestamp: tm, Value: 2}, {Timestamp: tm, Value: 3}, {Timestamp: tm, Value: 4}}, dm1.Values)
 }
 
 func TestToAPIMetricsSameInterval(t *testing.T) {
@@ -120,17 +120,17 @@ func TestToAPIMetricsSameInterval(t *testing.T) {
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
 		Host:   &hostname,
-		Values: []float64{},
+		Values: []MetricValue{},
 	}
 
-	dm.AddPoint(1)
-	dm.AddPoint(2)
-	dm.AddPoint(3)
+	dm.AddPoint(tm, 1)
+	dm.AddPoint(tm, 2)
+	dm.AddPoint(tm, 3)
 
-	batcher.AddMetric(tm, &dm)
+	batcher.AddMetric(&dm)
 
 	floatTime := float64(tm.Unix())
-	result := batcher.ToAPIMetrics(tm)
+	result := batcher.ToAPIMetrics()
 	expected := []APIMetric{
 		{
 			Name:       "metric-1",

--- a/internal/metrics/processor.go
+++ b/internal/metrics/processor.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -100,7 +100,7 @@ func (p *processor) processMetrics() {
 				shouldSendBatch = true
 				shouldExit = true
 			} else {
-				p.batcher.AddMetric(p.timeService.Now(), m)
+				p.batcher.AddMetric(m)
 			}
 		case <-ticker.C:
 			// We are ready to send a batch to our backend
@@ -122,7 +122,7 @@ func (p *processor) processMetrics() {
 }
 
 func (p *processor) sendMetricsBatch() error {
-	mts := p.batcher.ToAPIMetrics(p.timeService.Now())
+	mts := p.batcher.ToAPIMetrics()
 	if len(mts) > 0 {
 		err := p.client.SendMetrics(mts)
 		if err != nil {

--- a/internal/metrics/processor_test.go
+++ b/internal/metrics/processor_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -72,12 +72,12 @@ func TestProcessorBatches(t *testing.T) {
 	d1 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{1, 2, 3},
+		Values: []MetricValue{{Timestamp: mts.now, Value: 1}, {Timestamp: mts.now, Value: 2}, {Timestamp: mts.now, Value: 3}},
 	}
 	d2 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{4, 5, 6},
+		Values: []MetricValue{{Timestamp: mts.now, Value: 4}, {Timestamp: mts.now, Value: 5}, {Timestamp: mts.now, Value: 6}},
 	}
 
 	processor.AddMetric(&d1)
@@ -118,22 +118,22 @@ func TestProcessorBatchesPerTick(t *testing.T) {
 	d1 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{1, 2},
+		Values: []MetricValue{{Timestamp: firstTime, Value: 1}, {Timestamp: firstTime, Value: 2}},
 	}
 	d2 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{3},
+		Values: []MetricValue{{Timestamp: firstTime, Value: 3}},
 	}
 	d3 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{4, 5},
+		Values: []MetricValue{{Timestamp: secondTime, Value: 4}, {Timestamp: secondTime, Value: 5}},
 	}
 	d4 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{6},
+		Values: []MetricValue{{Timestamp: secondTime, Value: 6}},
 	}
 
 	processor.StartProcessing()
@@ -193,7 +193,7 @@ func TestProcessorPerformsRetry(t *testing.T) {
 	d1 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{1, 2, 3},
+		Values: []MetricValue{{Timestamp: mts.now, Value: 1}, {Timestamp: mts.now, Value: 2}, {Timestamp: mts.now, Value: 3}},
 	}
 
 	mc.err = errors.New("Some error")
@@ -218,7 +218,7 @@ func TestProcessorCancelsWithContext(t *testing.T) {
 	d1 := Distribution{
 		Name:   "metric-1",
 		Tags:   []string{"a", "b", "c"},
-		Values: []float64{1, 2, 3},
+		Values: []MetricValue{{Timestamp: mts.now, Value: 1}, {Timestamp: mts.now, Value: 2}, {Timestamp: mts.now, Value: 3}},
 	}
 
 	processor.AddMetric(&d1)


### PR DESCRIPTION
### What does this PR do?

Changes distribution metrics so their timestamps are preserved instead of being aggregated.
