### PR TITLE
Add Site configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ go get github.com/DataDog/datadog-lambda-go
 
 The following Datadog environment variables should be defined via the AWS CLI or Serverless Framework:
 
-- DATADOG_API_KEY
-- DATADOG_APP_KEY
+- DD_API_KEY
+
+Set the following Datadog environment variable to `datadoghq.eu` to send your data to the Datadog EU site.
+
+- DD_SITE
 
 ## Usage
 

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -117,9 +117,6 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 	}
 	if mc.Site == "" {
 		mc.Site = os.Getenv(DatadogSiteEnvVar)
-		if (mc.Site == "") {
-			mc.Site = 
-		}
 	}
 	return mc
 }

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -26,22 +26,23 @@ type (
 	Config struct {
 		// APIKey is your Datadog API key. This is used for sending metrics.
 		APIKey string
-		// AppKey is your Datadog App key. This is used for sending metrics.
-		AppKey string
 		// ShouldRetryOnFailure is used to turn on retry logic when sending metrics via the API. This can negatively effect the performance of your lambda,
 		// and should only be turned on if you can't afford to lose metrics data under poor network conditions.
 		ShouldRetryOnFailure bool
 		// BatchInterval is the period of time which metrics are grouped together for processing to be sent to the API or written to logs.
 		// Any pending metrics are flushed at the end of the lambda.
 		BatchInterval time.Duration
+		// Site is the host to send metrics to. If empty, this value is read from the 'DD_SITE' environment variable, or if that is empty
+		// will default to 'datadoghq.com'.
+		Site string
 	}
 )
 
 const (
 	// DatadogAPIKeyEnvVar is the environment variable that will be used as an API key by default
-	DatadogAPIKeyEnvVar = "DATADOG_API_KEY"
-	// DatadogAPPKeyEnvVar is the environment variable that will be used as an API key by default
-	DatadogAPPKeyEnvVar = "DATADOG_APP_KEY"
+	DatadogAPIKeyEnvVar = "DD_API_KEY"
+	// DatadogSiteEnvVar is the environment variable that will be used as the API host.
+	DatadogSiteEnvVar = "DD_SITE"
 )
 
 // WrapHandler is used to instrument your lambda functions, reading in context from API Gateway.
@@ -108,15 +109,17 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 		mc.BatchInterval = cfg.BatchInterval
 		mc.ShouldRetryOnFailure = cfg.ShouldRetryOnFailure
 		mc.APIKey = cfg.APIKey
-		mc.AppKey = cfg.AppKey
 	}
 
 	if mc.APIKey == "" {
 		mc.APIKey = os.Getenv(DatadogAPIKeyEnvVar)
 
 	}
-	if mc.AppKey == "" {
-		mc.AppKey = os.Getenv(DatadogAPIKeyEnvVar)
+	if mc.Site == "" {
+		mc.Site = os.Getenv(DatadogSiteEnvVar)
+		if (mc.Site == "") {
+			mc.Site = 
+		}
 	}
 	return mc
 }

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -25,7 +25,6 @@ type (
 	// APIClient send metrics to Datadog, via the Datadog API
 	APIClient struct {
 		apiKey     string
-		appKey     string
 		baseAPIURL string
 		httpClient *http.Client
 		context    context.Context
@@ -37,11 +36,10 @@ type (
 )
 
 // MakeAPIClient creates a new API client with the given api and app keys
-func MakeAPIClient(ctx context.Context, baseAPIURL, apiKey, appKey string) *APIClient {
+func MakeAPIClient(ctx context.Context, baseAPIURL, apiKey string) *APIClient {
 	httpClient := &http.Client{}
 	return &APIClient{
 		apiKey:     apiKey,
-		appKey:     appKey,
 		baseAPIURL: baseAPIURL,
 		httpClient: httpClient,
 		context:    ctx,
@@ -98,7 +96,6 @@ func (cl *APIClient) SendMetrics(metrics []APIMetric) error {
 func (cl *APIClient) addAPICredentials(req *http.Request) {
 	query := req.URL.Query()
 	query.Add(apiKeyParam, cl.apiKey)
-	query.Add(appKeyParam, cl.appKey)
 	req.URL.RawQuery = query.Encode()
 }
 

--- a/internal/metrics/api_test.go
+++ b/internal/metrics/api_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -20,14 +20,13 @@ import (
 
 const (
 	mockAPIKey = "12345"
-	mockAppKey = "678910"
 )
 
 func TestAddAPICredentials(t *testing.T) {
-	cl := MakeAPIClient(context.Background(), "", mockAPIKey, mockAppKey)
+	cl := MakeAPIClient(context.Background(), "", mockAPIKey)
 	req, _ := http.NewRequest("GET", "http://some-api.com/endpoint", nil)
 	cl.addAPICredentials(req)
-	assert.Equal(t, "http://some-api.com/endpoint?api_key=12345&application_key=678910", req.URL.String())
+	assert.Equal(t, "http://some-api.com/endpoint?api_key=12345", req.URL.String())
 }
 
 func TestPrewarmConnection(t *testing.T) {
@@ -35,11 +34,11 @@ func TestPrewarmConnection(t *testing.T) {
 	called := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		assert.Equal(t, "/validate?api_key=12345&application_key=678910", r.URL.String())
+		assert.Equal(t, "/validate?api_key=12345", r.URL.String())
 	}))
 	defer server.Close()
 
-	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey, mockAppKey)
+	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey)
 	err := cl.PrewarmConnection()
 
 	assert.NoError(t, err)
@@ -54,7 +53,7 @@ func TestSendMetricsSuccess(t *testing.T) {
 		body, _ := ioutil.ReadAll(r.Body)
 		s := string(body)
 
-		assert.Equal(t, "/series?api_key=12345&application_key=678910", r.URL.String())
+		assert.Equal(t, "/series?api_key=12345", r.URL.String())
 		assert.Equal(t, "{\"series\":[{\"metric\":\"metric-1\",\"tags\":[\"a\",\"b\",\"c\"],\"type\":\"distribution\",\"points\":[[1,2],[3,4],[5,6]]}]}", s)
 
 	}))
@@ -72,7 +71,7 @@ func TestSendMetricsSuccess(t *testing.T) {
 		},
 	}
 
-	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey, mockAppKey)
+	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey)
 	err := cl.SendMetrics(am)
 
 	assert.NoError(t, err)
@@ -87,7 +86,7 @@ func TestSendMetricsBadRequest(t *testing.T) {
 		body, _ := ioutil.ReadAll(r.Body)
 		s := string(body)
 
-		assert.Equal(t, "/series?api_key=12345&application_key=678910", r.URL.String())
+		assert.Equal(t, "/series?api_key=12345", r.URL.String())
 		assert.Equal(t, "{\"series\":[{\"metric\":\"metric-1\",\"tags\":[\"a\",\"b\",\"c\"],\"type\":\"distribution\",\"points\":[[1,2],[3,4],[5,6]]}]}", s)
 
 	}))
@@ -105,7 +104,7 @@ func TestSendMetricsBadRequest(t *testing.T) {
 		},
 	}
 
-	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey, mockAppKey)
+	cl := MakeAPIClient(context.Background(), server.URL, mockAPIKey)
 	err := cl.SendMetrics(am)
 
 	assert.Error(t, err)
@@ -131,7 +130,7 @@ func TestSendMetricsCantReachServer(t *testing.T) {
 		},
 	}
 
-	cl := MakeAPIClient(context.Background(), "httpa:///badly-formatted-url", mockAPIKey, mockAppKey)
+	cl := MakeAPIClient(context.Background(), "httpa:///badly-formatted-url", mockAPIKey)
 	err := cl.SendMetrics(am)
 
 	assert.Error(t, err)

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -11,11 +11,11 @@ package metrics
 import "time"
 
 const (
-	baseAPIURL           = "https://api.datadoghq.com/api/v1"
 	apiKeyParam          = "api_key"
 	appKeyParam          = "application_key"
 	defaultRetryInterval = time.Millisecond * 250
 	defaultBatchInterval = time.Second * 15
+	defaultSite          = "datadoghq.com"
 )
 
 // MetricType enumerates all the available metric types

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -11,6 +11,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -24,7 +25,7 @@ type (
 	// Config gives options for how the listener should work
 	Config struct {
 		APIKey               string
-		AppKey               string
+		Site                 string
 		ShouldRetryOnFailure bool
 		BatchInterval        time.Duration
 	}
@@ -32,7 +33,10 @@ type (
 
 // MakeListener initializes a new metrics lambda listener
 func MakeListener(config Config) Listener {
-	apiClient := MakeAPIClient(context.Background(), baseAPIURL, config.APIKey, config.AppKey)
+
+	baseAPIURL := fmt.Sprintf("https://api.%s/api/v1/", config.Site)
+
+	apiClient := MakeAPIClient(context.Background(), baseAPIURL, config.APIKey)
 	if config.BatchInterval <= 0 {
 		config.BatchInterval = defaultBatchInterval
 	}

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -34,6 +34,10 @@ type (
 // MakeListener initializes a new metrics lambda listener
 func MakeListener(config Config) Listener {
 
+	site := config.Site
+	if site == "" {
+		site = defaultSite
+	}
 	baseAPIURL := fmt.Sprintf("https://api.%s/api/v1/", config.Site)
 
 	apiClient := MakeAPIClient(context.Background(), baseAPIURL, config.APIKey)


### PR DESCRIPTION
Makes the Datadog site configurable, so user's can swap between the european api endpoint, and the north american one.
