### PR TITLE
Darcy.rayner/fix xray parents

### DIFF
--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -44,7 +44,7 @@ func ExtractTraceContext(ctx context.Context, ev json.RawMessage) (context.Conte
 		}
 		// Set parent ID to the functions parent.
 		xrayTraceContext, err := convertTraceContextFromXRay(ctx)
-		if err != nil {
+		if err == nil {
 			traceContext[parentIDHeader] = xrayTraceContext[parentIDHeader]
 		}
 

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -63,10 +63,13 @@ func GetTraceHeaders(ctx context.Context, useCurrentSegmentAsParent bool) map[st
 		if useCurrentSegmentAsParent {
 			segment := xray.GetSegment(ctx)
 			if segment != nil {
+				println("Xray current segment is set")
 				newParentID, err := convertXRayEntityIDToAPMParentID(segment.ID)
 				if err == nil {
 					parentID = newParentID
 				}
+			} else {
+				println("Xray current segment is empty, defaulting to global parent segment")
 			}
 		}
 

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -42,6 +42,12 @@ func ExtractTraceContext(ctx context.Context, ev json.RawMessage) (context.Conte
 		if err != nil {
 			return ctx, err
 		}
+		// Set parent ID to the functions parent.
+		xrayTraceContext, err := convertTraceContextFromXRay(ctx)
+		if err != nil {
+			traceContext[parentIDHeader] = xrayTraceContext[parentIDHeader]
+		}
+
 		return context.WithValue(ctx, traceContextKey, traceContext), nil
 	}
 
@@ -69,7 +75,7 @@ func GetTraceHeaders(ctx context.Context, useCurrentSegmentAsParent bool) map[st
 					parentID = newParentID
 				}
 			} else {
-				println("Xray current segment is empty, defaulting to global parent segment")
+				println("Xray current segment is empty, defaulting to parent segment")
 			}
 		}
 

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -69,13 +69,10 @@ func GetTraceHeaders(ctx context.Context, useCurrentSegmentAsParent bool) map[st
 		if useCurrentSegmentAsParent {
 			segment := xray.GetSegment(ctx)
 			if segment != nil {
-				println("Xray current segment is set")
 				newParentID, err := convertXRayEntityIDToAPMParentID(segment.ID)
 				if err == nil {
 					parentID = newParentID
 				}
-			} else {
-				println("Xray current segment is empty, defaulting to parent segment")
 			}
 		}
 

--- a/internal/trace/context_test.go
+++ b/internal/trace/context_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -155,7 +155,7 @@ func TestExtractTraceContextFromEvent(t *testing.T) {
 
 	expected := map[string]string{
 		traceIDHeader:          "1231452342",
-		parentIDHeader:         "45678910",
+		parentIDHeader:         "13334283619152181365", // Use the parentID from the context, not the event
 		samplingPriorityHeader: "2",
 	}
 	assert.Equal(t, expected, headers)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where incorrect parentID is used when receiving datadog trace headers.

Old:
<img width="1543" alt="Screen Shot 2019-06-06 at 2 17 09 PM" src="https://user-images.githubusercontent.com/50632605/59056338-f3827b80-8865-11e9-8529-ce7b73c673c7.png">
New:
<img width="1543" alt="Screen Shot 2019-06-06 at 2 18 10 PM" src="https://user-images.githubusercontent.com/50632605/59056345-f7160280-8865-11e9-8042-afbfdc73a4a7.png">
