### PR TITLE
Darcy.rayner/log forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Which Datadog site to use. Set this to `datadoghq.eu` to send your data to the D
 
 How much logging datadog-lambda-go should do. Set this to "debug" for extensive logs.
 
-### DATADOG_FLUSH_TO_LOG
+### DD_FLUSH_TO_LOG
 
 If your Lambda function powers a performance-critical task (e.g., a consumer-facing API). You can avoid the added latencies of metric-submitting API calls, by setting this value to true. Custom metrics will be submitted asynchronously through CloudWatch Logs and the Datadog log forwarder.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Which Datadog site to use. Set this to `datadoghq.eu` to send your data to the D
 
 How much logging datadog-lambda-go should do. Set this to "debug" for extensive logs.
 
+### DATADOG_FLUSH_TO_LOG
+
+If your Lambda function powers a performance-critical task (e.g., a consumer-facing API). You can avoid the added latencies of metric-submitting API calls, by setting this value to true. Custom metrics will be submitted asynchronously through CloudWatch Logs and the Datadog log forwarder.
+
 ## Usage
 
 Datadog needs to be able to read headers from the incoming Lambda event. Wrap your Lambda handler function like so:

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -58,7 +58,7 @@ const (
 	// if it equals "debug" everything will be logged.
 	DatadogLogLevelEnvVar = "DD_LOG_LEVEL"
 	// DatadogShouldUseLogForwarderEnvVar is the environment variable that is used to enable log forwarding of metrics.
-	DatadogShouldUseLogForwarderEnvVar = "DATADOG_FLUSH_TO_LOG"
+	DatadogShouldUseLogForwarderEnvVar = "DD_FLUSH_TO_LOG"
 	// DefaultSite to send API messages to.
 	DefaultSite = "datadoghq.com"
 )

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -105,6 +105,7 @@ func Distribution(metric string, value float64, tags ...string) {
 		logger.Error(fmt.Errorf("couldn't get metrics listener from current context"))
 		return
 	}
+	listener.AddDistributionMetric(metric, value, tags...)
 }
 
 func (cfg *Config) toMetricsConfig() metrics.Config {

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -122,16 +122,6 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 		mc.ShouldUseLogForwarder = cfg.ShouldUseLogForwarder
 	}
 
-	if mc.APIKey == "" {
-		mc.APIKey = os.Getenv(DatadogAPIKeyEnvVar)
-
-	}
-	if mc.KMSAPIKey == "" {
-		mc.KMSAPIKey = os.Getenv(DatadogKMSAPIKeyEnvVar)
-	}
-	if mc.APIKey == "" && mc.KMSAPIKey == "" {
-		logger.Error(fmt.Errorf("couldn't read DD_API_KEY or DD_KMS_API_KEY from environment"))
-	}
 	if mc.Site == "" {
 		mc.Site = os.Getenv(DatadogSiteEnvVar)
 	}
@@ -143,6 +133,17 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 	if !mc.ShouldUseLogForwarder {
 		shouldUseLogForwarder := os.Getenv(DatadogShouldUseLogForwarderEnvVar)
 		mc.ShouldUseLogForwarder = strings.EqualFold(shouldUseLogForwarder, "true")
+	}
+
+	if mc.APIKey == "" {
+		mc.APIKey = os.Getenv(DatadogAPIKeyEnvVar)
+
+	}
+	if mc.KMSAPIKey == "" {
+		mc.KMSAPIKey = os.Getenv(DatadogKMSAPIKeyEnvVar)
+	}
+	if mc.APIKey == "" && mc.KMSAPIKey == "" && !mc.ShouldUseLogForwarder {
+		logger.Error(fmt.Errorf("couldn't read DD_API_KEY or DD_KMS_API_KEY from environment"))
 	}
 
 	return mc

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -15,7 +15,6 @@ const (
 	appKeyParam          = "application_key"
 	defaultRetryInterval = time.Millisecond * 250
 	defaultBatchInterval = time.Second * 15
-	defaultSite          = "datadoghq.com"
 )
 
 // MetricType enumerates all the available metric types

--- a/internal/metrics/context.go
+++ b/internal/metrics/context.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -14,16 +14,16 @@ type contextKeytype int
 
 var traceContextKey = new(contextKeytype)
 
-// GetProcessor retrieves the processor from a context object.
-func GetProcessor(ctx context.Context) Processor {
+// GetListener retrieves the metrics listener from a context object.
+func GetListener(ctx context.Context) *Listener {
 	result := ctx.Value(traceContextKey)
 	if result == nil {
 		return nil
 	}
-	return result.(Processor)
+	return result.(*Listener)
 }
 
-// AddProcessor adds a processor to a context object
-func AddProcessor(ctx context.Context, processor Processor) context.Context {
-	return context.WithValue(ctx, traceContextKey, processor)
+// AddListener adds a metrics listener to a context object
+func AddListener(ctx context.Context, listener *Listener) context.Context {
+	return context.WithValue(ctx, traceContextKey, listener)
 }

--- a/internal/metrics/context_test.go
+++ b/internal/metrics/context_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -17,12 +17,13 @@ import (
 
 func TestGetProcessorEmptyContext(t *testing.T) {
 	ctx := context.Background()
-	result := GetProcessor(ctx)
+	result := GetListener(ctx)
 	assert.Nil(t, result)
 }
 
 func TestGetProcessorSuccess(t *testing.T) {
-	ctx := AddProcessor(context.Background(), MakeProcessor(context.Background(), nil, nil, 0, false))
-	result := GetProcessor(ctx)
+	lst := MakeListener(Config{})
+	ctx := AddListener(context.Background(), &lst)
+	result := GetListener(ctx)
 	assert.NotNil(t, result)
 }

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -98,6 +98,7 @@ func (l *Listener) AddDistributionMetric(metric string, value float64, tags ...s
 	tags = append(tags, getRuntimeTag())
 
 	if l.config.ShouldUseLogForwarder {
+
 		unixTime := time.Now().Unix()
 		lm := logMetric{
 			MetricName: metric,
@@ -110,7 +111,8 @@ func (l *Listener) AddDistributionMetric(metric string, value float64, tags ...s
 			logger.Error(fmt.Errorf("failed to marshall metric for log forwarder with error %v", err))
 			return
 		}
-		println(string(result))
+		payload := string(result)
+		println(payload)
 		return
 	}
 	m := Distribution{

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -98,7 +98,7 @@ func (l *Listener) AddDistributionMetric(metric string, value float64, tags ...s
 	tags = append(tags, getRuntimeTag())
 
 	if l.config.ShouldUseLogForwarder {
-
+		logger.Debug("sending metric via log forwarder")
 		unixTime := time.Now().Unix()
 		lm := logMetric{
 			MetricName: metric,

--- a/internal/metrics/listener_test.go
+++ b/internal/metrics/listener_test.go
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed
  * under the Apache License Version 2.0.
- * 
+ *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2019 Datadog, Inc.
  */
@@ -11,15 +11,17 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHandlerAddsProcessorToContext(t *testing.T) {
+func TestHandlerAddsItselfToContext(t *testing.T) {
 	listener := MakeListener(Config{})
 	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
-	pr := GetProcessor(ctx)
+	pr := GetListener(ctx)
 	assert.NotNil(t, pr)
 }
 
@@ -27,7 +29,23 @@ func TestHandlerFinishesProcessing(t *testing.T) {
 	listener := MakeListener(Config{})
 	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
 
-	pr := GetProcessor(ctx).(*processor)
 	listener.HandlerFinished(ctx)
-	assert.False(t, pr.isProcessing)
+	assert.False(t, listener.processor.IsProcessing())
+}
+
+func TestAddDistributionMetricWithAPI(t *testing.T) {
+
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/distribution_points?api_key=12345", r.URL.String())
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	listener := MakeListener(Config{APIKey: "12345", Site: server.URL})
+	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
+	listener.AddDistributionMetric("the-metric", 2, "tag:a", "tag:b")
+	listener.HandlerFinished(ctx)
+	assert.True(t, called)
 }

--- a/internal/metrics/listener_test.go
+++ b/internal/metrics/listener_test.go
@@ -49,3 +49,18 @@ func TestAddDistributionMetricWithAPI(t *testing.T) {
 	listener.HandlerFinished(ctx)
 	assert.True(t, called)
 }
+
+func TestAddDistributionMetricWithLogForwarder(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	listener := MakeListener(Config{APIKey: "12345", Site: server.URL, ShouldUseLogForwarder: true})
+	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
+	listener.AddDistributionMetric("the-metric", 2, "tag:a", "tag:b")
+	listener.HandlerFinished(ctx)
+	assert.False(t, called)
+}

--- a/internal/metrics/processor.go
+++ b/internal/metrics/processor.go
@@ -27,6 +27,8 @@ type (
 		StartProcessing()
 		// FinishProcessing shuts down the agent, and tries to flush any remaining metrics
 		FinishProcessing()
+		// Whether the processor is still processing
+		IsProcessing() bool
 	}
 
 	processor struct {
@@ -81,6 +83,10 @@ func (p *processor) FinishProcessing() {
 	// Closes the metrics channel, and waits for the last send to complete
 	close(p.metricsChan)
 	p.waitGroup.Wait()
+}
+
+func (p *processor) IsProcessing() bool {
+	return p.isProcessing
 }
 
 func (p *processor) processMetrics() {


### PR DESCRIPTION
### What does this PR do?

Adds DD_FLUSH_TO_LOG support, (log forwarding). Also, there is a refactor here that moves more logic from ddlambda.go to the metrics around creating metrics. This was to keep the logic around using the log forwarder simple and contained to the metrics package.
