### PR TITLE
Support mixed case trace headers

### DIFF
--- a/internal/testdata/non-proxy-mixed-case-metadata.json
+++ b/internal/testdata/non-proxy-mixed-case-metadata.json
@@ -1,0 +1,11 @@
+{
+  "my-custom-event": {
+    "hello": 100
+  },
+  "fake-id": "12345678910",
+  "headers": {
+    "X-Datadog-Trace-Id": "1231452342",
+    "X-Datadog-Parent-Id": "45678910",
+    "X-Datadog-Sampling-Priority": "2"
+  }
+}

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -120,17 +120,22 @@ func unmarshalEventForTraceContext(ev json.RawMessage) (map[string]string, bool)
 		return traceContext, false
 	}
 
-	traceID, ok := eh.Headers[traceIDHeader]
+	lowercaseHeaders := map[string]string{}
+	for k, v := range eh.Headers {
+		lowercaseHeaders[strings.ToLower(k)] = v
+	}
+
+	traceID, ok := lowercaseHeaders[traceIDHeader]
 	if !ok {
 		return traceContext, false
 	}
 
-	parentID, ok := eh.Headers[parentIDHeader]
+	parentID, ok := lowercaseHeaders[parentIDHeader]
 	if !ok {
 		return traceContext, false
 	}
 
-	samplingPriority, ok := eh.Headers[samplingPriorityHeader]
+	samplingPriority, ok := lowercaseHeaders[samplingPriorityHeader]
 	if !ok {
 		return traceContext, false
 	}

--- a/internal/trace/context_test.go
+++ b/internal/trace/context_test.go
@@ -61,6 +61,20 @@ func TestUnmarshalEventForTraceMetadataNonProxyEvent(t *testing.T) {
 	assert.Equal(t, expected, headers)
 }
 
+func TestUnmarshalEventForTraceMetadataWithMixedCaseHeaders(t *testing.T) {
+	ev := loadRawJSON(t, "../testdata/non-proxy-mixed-case-metadata.json")
+
+	headers, ok := unmarshalEventForTraceContext(*ev)
+	assert.True(t, ok)
+
+	expected := map[string]string{
+		traceIDHeader:          "1231452342",
+		parentIDHeader:         "45678910",
+		samplingPriorityHeader: "2",
+	}
+	assert.Equal(t, expected, headers)
+}
+
 func TestUnmarshalEventForInvalidData(t *testing.T) {
 	ev := loadRawJSON(t, "../testdata/invalid.json")
 


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Supports incoming mixed case trace headers.

### Motivation

Some libraries/frameworks will force mixed casing when sending headers. We should support those.

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
