### PR TITLE
Add option to specify timestamp of custom metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ func myHandler(ctx context.Context, event MyEvent) (string, error) {
 
 ## Custom Metrics
 
-Custom metrics can be submitted using the `Distribution` function. The metrics are submitted as [distribution metrics](https://docs.datadoghq.com/graphing/metrics/distributions/).
+Custom metrics can be submitted using the `Metric` function. The metrics are submitted as [distribution metrics](https://docs.datadoghq.com/graphing/metrics/distributions/).
 
-**IMPORTANT NOTE:** If you have already been submitting the same custom metric as non-distribution metric (e.g., gauge, count, or histogram) without using the datadog-lambda-go lib, you MUST pick a new metric name to use for `ddlambda.Distribution`. Otherwise that existing metric will be converted to a distribution metric and the historical data prior to the conversion will be no longer queryable.
+**IMPORTANT NOTE:** If you have already been submitting the same custom metric as non-distribution metric (e.g., gauge, count, or histogram) without using the datadog-lambda-go lib, you MUST pick a new metric name to use for `ddlambda.Metric`. Otherwise that existing metric will be converted to a distribution metric and the historical data prior to the conversion will be no longer queryable.
 
 ```go
-ddlambda.Distribution(
+ddlambda.Metric(
   "coffee_house.order_value", // Metric name
   12.45, // The value
   "product:latte", "order:online" // Associated tags

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -99,13 +99,24 @@ func GetContext() context.Context {
 }
 
 // Distribution sends a distribution metric to DataDog
+// Deprecated: Use Metric method instead
 func Distribution(metric string, value float64, tags ...string) {
+	Metric(metric, value, tags...)
+}
+
+// Metric sends a distribution metric to DataDog
+func Metric(metric string, value float64, tags ...string) {
+	MetricWithTimestamp(metric, value, time.Now(), tags...)
+}
+
+// MetricWithTimestamp sends a distribution metric to DataDog with a custom timestamp
+func MetricWithTimestamp(metric string, value float64, timestamp time.Time, tags ...string) {
 	listener := metrics.GetListener(GetContext())
 	if listener == nil {
 		logger.Error(fmt.Errorf("couldn't get metrics listener from current context"))
 		return
 	}
-	listener.AddDistributionMetric(metric, value, tags...)
+	listener.AddDistributionMetric(metric, value, timestamp, tags...)
 }
 
 func (cfg *Config) toMetricsConfig() metrics.Config {

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -92,14 +92,14 @@ func (l *Listener) HandlerFinished(ctx context.Context) {
 }
 
 // AddDistributionMetric sends a distribution metric
-func (l *Listener) AddDistributionMetric(metric string, value float64, tags ...string) {
+func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp time.Time, tags ...string) {
 
 	// We add our own runtime tag to the metric for version tracking
 	tags = append(tags, getRuntimeTag())
 
 	if l.config.ShouldUseLogForwarder {
 		logger.Debug("sending metric via log forwarder")
-		unixTime := time.Now().Unix()
+		unixTime := timestamp.Unix()
 		lm := logMetric{
 			MetricName: metric,
 			Value:      value,
@@ -120,7 +120,7 @@ func (l *Listener) AddDistributionMetric(metric string, value float64, tags ...s
 		Tags:   tags,
 		Values: []MetricValue{},
 	}
-	m.AddPoint(time.Now(), value)
+	m.AddPoint(timestamp, value)
 	logger.Debug(fmt.Sprintf("adding metric \"%s\", with value %f", metric, value))
 	l.processor.AddMetric(&m)
 }

--- a/internal/metrics/listener_test.go
+++ b/internal/metrics/listener_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -45,7 +46,7 @@ func TestAddDistributionMetricWithAPI(t *testing.T) {
 
 	listener := MakeListener(Config{APIKey: "12345", Site: server.URL})
 	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
-	listener.AddDistributionMetric("the-metric", 2, "tag:a", "tag:b")
+	listener.AddDistributionMetric("the-metric", 2, time.Now(), "tag:a", "tag:b")
 	listener.HandlerFinished(ctx)
 	assert.True(t, called)
 }
@@ -60,7 +61,7 @@ func TestAddDistributionMetricWithLogForwarder(t *testing.T) {
 
 	listener := MakeListener(Config{APIKey: "12345", Site: server.URL, ShouldUseLogForwarder: true})
 	ctx := listener.HandlerStarted(context.Background(), json.RawMessage{})
-	listener.AddDistributionMetric("the-metric", 2, "tag:a", "tag:b")
+	listener.AddDistributionMetric("the-metric", 2, time.Now(), "tag:a", "tag:b")
 	listener.HandlerFinished(ctx)
 	assert.False(t, called)
 }


### PR DESCRIPTION
### What does this PR do?

* Adds the ability to configure the timestamp sent with metrics
* Renames the `Distribution` function to `Metric`

### Motivation

From [this feature request](https://github.com/DataDog/datadog-lambda-go/issues/11)
