### PR TITLE
add enhanced metrics: invocations and errors

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -45,6 +45,8 @@ type (
 
 		// DebugLogging will turn on extended debug logging.
 		DebugLogging bool
+		// EnhancedMetrics enables the reporting of enhanced metrics under `aws.lambda.enhanced*` and adds enhanced metric tags
+		EnhancedMetrics bool
 	}
 )
 
@@ -62,6 +64,8 @@ const (
 	DatadogShouldUseLogForwarderEnvVar = "DD_FLUSH_TO_LOG"
 	// DefaultSite to send API messages to.
 	DefaultSite = "datadoghq.com"
+	// EnhancedMetrics is the environment variable used to enable enhanced metrics
+	EnhancedMetrics = "DD_ENHANCED_METRICS"
 )
 
 // WrapHandler is used to instrument your lambda functions, reading in context from API Gateway.
@@ -180,6 +184,11 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 	}
 	if mc.APIKey == "" && mc.KMSAPIKey == "" && !mc.ShouldUseLogForwarder {
 		logger.Error(fmt.Errorf("couldn't read DD_API_KEY or DD_KMS_API_KEY from environment"))
+	}
+
+	if !mc.EnhancedMetrics {
+		enhancedMetrics := os.Getenv(EnhancedMetrics)
+		mc.EnhancedMetrics = strings.EqualFold(enhancedMetrics, "true")
 	}
 
 	return mc

--- a/internal/metrics/listener_test.go
+++ b/internal/metrics/listener_test.go
@@ -11,6 +11,7 @@ package metrics
 import (
 	"context"
 	"encoding/json"
+	"github.com/aws/aws-lambda-go/lambdacontext"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,4 +65,94 @@ func TestAddDistributionMetricWithLogForwarder(t *testing.T) {
 	listener.AddDistributionMetric("the-metric", 2, time.Now(), "tag:a", "tag:b")
 	listener.HandlerFinished(ctx)
 	assert.False(t, called)
+}
+
+func TestGetEnhancedMetricsTags(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cold_start", false)
+
+	lambdacontext.MemoryLimitInMB = 256
+	lambdacontext.FunctionName = "go-lambda-test"
+	lc := &lambdacontext.LambdaContext{
+		InvokedFunctionArn: "arn:aws:lambda:us-east-1:123497558138:function:go-lambda-test",
+	}
+	tags := getEnhancedMetricsTags(lambdacontext.NewContext(ctx, lc))
+
+	assert.ElementsMatch(t, tags, []string{"functionname:go-lambda-test", "region:us-east-1", "memorysize:256", "cold_start:false", "account_id:123497558138"})
+}
+
+func TestGetEnhancedMetricsTagsNoLambdaContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "cold_start", true)
+	tags := getEnhancedMetricsTags(ctx)
+
+	assert.Empty(t, tags)
+}
+
+func TestSubmitEnhancedMetrics(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+	ml := MakeListener(
+		Config{
+			APIKey:                "abc-123",
+			Site:                  server.URL,
+			EnhancedMetrics:       true,
+		},
+	)
+	ctx := context.WithValue(context.Background(), "cold_start", false)
+
+	ctx = ml.HandlerStarted(ctx, json.RawMessage{})
+	ml.HandlerFinished(ctx)
+
+	assert.True(t, called)
+}
+
+func TestDoNotSubmitEnhancedMetrics(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	ml := MakeListener(
+		Config{
+			APIKey:                "abc-123",
+			Site:                  server.URL,
+			EnhancedMetrics:       false,
+		},
+	)
+	ctx := context.WithValue(context.Background(), "cold_start", true)
+
+	ctx = ml.HandlerStarted(ctx, json.RawMessage{})
+	ml.HandlerFinished(ctx)
+
+	assert.False(t, called)
+}
+
+func TestSubmitEnhancedMetricsOnlyErrors(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	ml := MakeListener(
+		Config{
+			APIKey:                "abc-123",
+			Site:                  server.URL,
+			EnhancedMetrics:       false,
+		},
+	)
+	ctx := context.WithValue(context.Background(), "cold_start", true)
+
+	ctx = ml.HandlerStarted(ctx, json.RawMessage{})
+	ml.config.EnhancedMetrics = true
+	ctx = context.WithValue(ctx, "error", true)
+	ml.HandlerFinished(ctx)
+
+	assert.True(t, called)
 }

--- a/internal/wrapper/wrap_handler_test.go
+++ b/internal/wrapper/wrap_handler_test.go
@@ -12,15 +12,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/DataDog/datadog-lambda-go/internal/metrics"
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambdacontext"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/assert"
 )
 
 type (
@@ -267,74 +264,4 @@ func TestWrapHandlerReturnsOriginalHandlerIfInvalid(t *testing.T) {
 
 	assert.Equal(t, reflect.ValueOf(handler).Pointer(), reflect.ValueOf(wrappedHandler).Pointer())
 
-}
-
-func TestGetEnhancedMetricsTags(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "cold_start", false)
-
-	lambdacontext.MemoryLimitInMB = 256
-	lambdacontext.FunctionName = "go-lambda-test"
-	lc := &lambdacontext.LambdaContext{
-		InvokedFunctionArn: "arn:aws:lambda:us-east-1:123497558138:function:go-lambda-test",
-	}
-	tags := getEnhancedMetricsTags(lambdacontext.NewContext(ctx, lc))
-
-	assert.ElementsMatch(t, tags, []string{"functionname:go-lambda-test", "region:us-east-1", "memorysize:256", "cold_start:false", "account_id:123497558138"})
-}
-
-func TestGetEnhancedMetricsTagsNoLambdaContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), "cold_start", true)
-	tags := getEnhancedMetricsTags(ctx)
-
-	assert.Empty(t, tags)
-}
-
-func TestSubmitEnhancedMetrics(t *testing.T) {
-	called := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer server.Close()
-
-	ml := metrics.MakeListener(
-		metrics.Config{
-			APIKey:                "abc-123",
-			Site:                  server.URL,
-			EnhancedMetrics:       true,
-		},
-	)
-	ctx := context.WithValue(context.Background(), "cold_start", false)
-
-	ctx = ml.HandlerStarted(ctx, json.RawMessage{})
-	submitEnhancedMetrics("invocations", ctx)
-	submitEnhancedMetrics("errors", ctx)
-	ml.HandlerFinished(ctx)
-
-	assert.True(t, called)
-}
-
-func TestDoNotSubmitEnhancedMetrics(t *testing.T) {
-	called := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer server.Close()
-
-	ml := metrics.MakeListener(
-		metrics.Config{
-			APIKey:                "abc-123",
-			Site:                  server.URL,
-			EnhancedMetrics:       false,
-		},
-	)
-	ctx := context.WithValue(context.Background(), "cold_start", true)
-
-	ctx = ml.HandlerStarted(ctx, json.RawMessage{})
-	submitEnhancedMetrics("invocations", ctx)
-	submitEnhancedMetrics("errors", ctx)
-	ml.HandlerFinished(ctx)
-
-	assert.False(t, called)
 }


### PR DESCRIPTION
### What does this PR do?

Adds the enhanced metrics of `aws.lambda.enhanced.invocations` and `aws.lambda.enhanced.errors` and the respective tags from the Lambda Context. This includes the custom tag of  `cold_start:true|false`.

### Testing Guidelines

Includes unit tests for proper grabbing of enhanced metric tags, and for submission of the metric to a host/site.