### PR TITLE
Always send enhanced metrics through logs

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -129,7 +129,7 @@ func MetricWithTimestamp(metric string, value float64, timestamp time.Time, tags
 		logger.Error(fmt.Errorf("couldn't get metrics listener from current context"))
 		return
 	}
-	listener.AddDistributionMetric(metric, value, timestamp, tags...)
+	listener.AddDistributionMetric(metric, value, timestamp, false, tags...)
 }
 
 // InvokeDryRun is a utility to easily run your lambda for testing

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -3,7 +3,9 @@ package logger
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"os"
 )
 
 // LogLevel represents the level of logging that should be performed
@@ -17,12 +19,19 @@ const (
 )
 
 var (
-	logLevel = LevelError
+	logLevel           = LevelError
+	output   io.Writer = os.Stdout
 )
 
 // SetLogLevel set the level of logging for the ddlambda
 func SetLogLevel(ll LogLevel) {
 	logLevel = ll
+}
+
+//
+func SetOutput(w io.Writer) {
+	log.SetOutput(w)
+	output = w
 }
 
 // Error logs a structured error message to stdout
@@ -59,4 +68,9 @@ func Debug(message string) {
 	result, _ := json.Marshal(finalMessage)
 
 	log.Println(string(result))
+}
+
+// Raw prints a raw message to the logs.
+func Raw(message string) {
+	fmt.Fprintln(output, message)
 }

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -28,7 +28,7 @@ func SetLogLevel(ll LogLevel) {
 	logLevel = ll
 }
 
-//
+// SetOutput changes the writer for the logger
 func SetOutput(w io.Writer) {
 	log.SetOutput(w)
 	output = w

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -99,12 +99,12 @@ func (l *Listener) HandlerFinished(ctx context.Context) {
 }
 
 // AddDistributionMetric sends a distribution metric
-func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp time.Time, tags ...string) {
+func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp time.Time, forceLogForwarder bool, tags ...string) {
 
 	// We add our own runtime tag to the metric for version tracking
 	tags = append(tags, getRuntimeTag())
 
-	if l.config.ShouldUseLogForwarder {
+	if l.config.ShouldUseLogForwarder || forceLogForwarder {
 		logger.Debug("sending metric via log forwarder")
 		unixTime := timestamp.Unix()
 		lm := logMetric{
@@ -119,7 +119,7 @@ func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp
 			return
 		}
 		payload := string(result)
-		println(payload)
+		logger.Raw(payload)
 		return
 	}
 	m := Distribution{
@@ -140,7 +140,7 @@ func getRuntimeTag() string {
 func (l *Listener) submitEnhancedMetrics(metricName string, ctx context.Context) {
 	if l.config.EnhancedMetrics {
 		tags := getEnhancedMetricsTags(ctx)
-		l.AddDistributionMetric(fmt.Sprintf("aws.lambda.enhanced.%s", metricName), 1, time.Now(), tags...)
+		l.AddDistributionMetric(fmt.Sprintf("aws.lambda.enhanced.%s", metricName), 1, time.Now(), true, tags...)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Modifies enhanced metrics to always be flushed to logs, when enabled.
Previously enhanced metrics were enabled by default, but they would send over http if the logs option was turned off.
