### PR TITLE
fix the sample of ddlambda.Metric in READ.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ Custom metrics can be submitted using the `Metric` function. The metrics are sub
 **IMPORTANT NOTE:** If you have already been submitting the same custom metric as non-distribution metric (e.g., gauge, count, or histogram) without using the datadog-lambda-go lib, you MUST pick a new metric name to use for `ddlambda.Metric`. Otherwise that existing metric will be converted to a distribution metric and the historical data prior to the conversion will be no longer queryable.
 
 ```go
+tags := []string{"product:latte", "order:online"}
+
 ddlambda.Metric(
   "coffee_house.order_value", // Metric name
   12.45, // The value
-  "product:latte", "order:online" // Associated tags
+  tags... // Associated tags
 )
 ```
 


### PR DESCRIPTION
### What does this PR do?

I updated the sample code of `ddlambda.Metric` in READ.md.

### Motivation

When I submitted the custom metric just like sample, the tags were not separated correctly.