### PR TITLE
enable DD_TAGS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ If your Lambda function powers a performance-critical task (e.g., a consumer-fac
 
 The Lambda layer will increment a Lambda integration metric called `aws.lambda.enhanced.invocations` with each invocation and `aws.lambda.enhanced.errors` if the invocation results in an error. These metrics are tagged with the function name, region, account, runtime, memorysize, and `cold_start:true|false`. This is enabled by default.
 
+### DD_TAGS
+
+A comma-delimetered list of tag:value pairs which are added to all metrics emitted (ie. in addition to any tags used when calling the `.Metric()` function).
+
+Example - This will add 2 tags to all metrics emitted from this runtime:
+```
+DD_TAGS=layer:api,team:intake
+```
+
 ## Usage
 
 Datadog needs to be able to read headers from the incoming Lambda event. Wrap your Lambda handler function like so:

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -203,7 +203,7 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 		val := os.Getenv(DatadogGlobalTags)
 		mc.GlobalTags = []string{}
 		if len(val) > 0 {
-			mc.GlobalTags = strings.Split(os.Getenv(DatadogGlobalTags), ",")
+			mc.GlobalTags = strings.Split(val, ",")
 		}
 	}
 

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -47,6 +47,9 @@ type (
 		DebugLogging bool
 		// EnhancedMetrics enables the reporting of enhanced metrics under `aws.lambda.enhanced*` and adds enhanced metric tags
 		EnhancedMetrics bool
+
+		// GlobalTags are normal tags which are appended to every metric.
+		GlobalTags []string
 	}
 )
 
@@ -62,6 +65,8 @@ const (
 	DatadogLogLevelEnvVar = "DD_LOG_LEVEL"
 	// DatadogShouldUseLogForwarderEnvVar is the environment variable that is used to enable log forwarding of metrics.
 	DatadogShouldUseLogForwarderEnvVar = "DD_FLUSH_TO_LOG"
+	// DatadogGlobalTags is the environment variable used to add tags to all metrics
+	DatadogGlobalTags = "DD_TAGS"
 	// DefaultSite to send API messages to.
 	DefaultSite = "datadoghq.com"
 	// DefaultEnhancedMetrics enables enhanced metrics by default.
@@ -192,6 +197,14 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 	}
 	if !mc.EnhancedMetrics {
 		mc.EnhancedMetrics = strings.EqualFold(enhancedMetrics, "true")
+	}
+
+	if mc.GlobalTags == nil {
+		val := os.Getenv(DatadogGlobalTags)
+		mc.GlobalTags = []string{}
+		if len(val) > 0 {
+			mc.GlobalTags = strings.Split(os.Getenv(DatadogGlobalTags), ",")
+		}
 	}
 
 	return mc

--- a/ddlambda_test.go
+++ b/ddlambda_test.go
@@ -11,8 +11,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/DataDog/datadog-lambda-go/internal/metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,4 +47,74 @@ func TestMetricsSubmitWithWrapper(t *testing.T) {
 		Site:   server.URL,
 	})
 	assert.True(t, called)
+}
+
+func TestConfig_toMetricsConfig(t *testing.T) {
+	type envvars struct {
+		DatadogAPIKeyEnvVar    string
+		DatadogKMSAPIKeyEnvVar string
+		DatadogSiteEnvVar      string
+		DatadogGlobalTags      string
+	}
+	tests := map[string]struct {
+		config  *Config
+		envvars envvars
+		want    metrics.Config
+	}{
+		"with no env vars": {
+			config:  &Config{},
+			envvars: envvars{},
+			want: metrics.Config{
+				APIKey:                "",
+				KMSAPIKey:             "",
+				Site:                  "https://api.datadoghq.com/api/v1",
+				ShouldRetryOnFailure:  false,
+				ShouldUseLogForwarder: false,
+				BatchInterval:         0,
+				EnhancedMetrics:       true,
+				GlobalTags:            []string{},
+			},
+		},
+		"with env vars": {
+			config: &Config{},
+			envvars: envvars{
+				DatadogAPIKeyEnvVar:    "fooAPIKeyEnvVar",
+				DatadogKMSAPIKeyEnvVar: "fooKMSAPIKeyEnvVar",
+				DatadogSiteEnvVar:      "fooSiteEnvVar.com",
+				DatadogGlobalTags:      "key1:val1,key2:val2",
+			},
+			want: metrics.Config{
+				APIKey:                "fooAPIKeyEnvVar",
+				KMSAPIKey:             "fooKMSAPIKeyEnvVar",
+				Site:                  "https://api.fooSiteEnvVar.com/api/v1",
+				ShouldRetryOnFailure:  false,
+				ShouldUseLogForwarder: false,
+				BatchInterval:         0,
+				EnhancedMetrics:       true,
+				GlobalTags:            []string{"key1:val1", "key2:val2"},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// set env vars
+			os.Setenv(DatadogAPIKeyEnvVar, test.envvars.DatadogAPIKeyEnvVar)
+			os.Setenv(DatadogKMSAPIKeyEnvVar, test.envvars.DatadogKMSAPIKeyEnvVar)
+			os.Setenv(DatadogSiteEnvVar, test.envvars.DatadogSiteEnvVar)
+			os.Setenv(DatadogGlobalTags, test.envvars.DatadogGlobalTags)
+
+			// run
+			got := test.config.toMetricsConfig()
+
+			// assert
+			assert.EqualValues(t, test.want, got)
+
+			// cleanup
+			os.Unsetenv(DatadogAPIKeyEnvVar)
+			os.Unsetenv(DatadogKMSAPIKeyEnvVar)
+			os.Unsetenv(DatadogSiteEnvVar)
+			os.Unsetenv(DatadogGlobalTags)
+		})
+	}
 }

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -104,7 +104,9 @@ func (l *Listener) HandlerFinished(ctx context.Context) {
 func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp time.Time, forceLogForwarder bool, tags ...string) {
 
 	// add global tabs
-	tags = append(tags, l.config.GlobalTags...)
+	if l.config.GlobalTags != nil && len(l.config.GlobalTags) > 0 {
+		tags = append(tags, l.config.GlobalTags...)
+	}
 
 	// We add our own runtime tag to the metric for version tracking
 	tags = append(tags, getRuntimeTag())

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -12,10 +12,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-lambda-go/lambdacontext"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-lambda-go/lambdacontext"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 )
@@ -37,6 +38,7 @@ type (
 		ShouldUseLogForwarder bool
 		BatchInterval         time.Duration
 		EnhancedMetrics       bool
+		GlobalTags            []string
 	}
 
 	logMetric struct {
@@ -100,6 +102,9 @@ func (l *Listener) HandlerFinished(ctx context.Context) {
 
 // AddDistributionMetric sends a distribution metric
 func (l *Listener) AddDistributionMetric(metric string, value float64, timestamp time.Time, forceLogForwarder bool, tags ...string) {
+
+	// add global tabs
+	tags = append(tags, l.config.GlobalTags...)
 
 	// We add our own runtime tag to the metric for version tracking
 	tags = append(tags, getRuntimeTag())


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

see: https://github.com/DataDog/datadog-lambda-go/issues/35

This change enables the env var `DD_TAGS`

Example:
Running with `DD_TAGS=key1:val1` will add the tag `key1:val1` to all metrics send from this SDK.

### Motivation

This env var exists on other Datadog SDK's, and enables a simple way to apply context to all metrics.

### Testing Guidelines

Added 2 new tests:
1. ensure the metrics package applied `GlobalTags` to emitted metrics
2. ensure `DD_TAGS` env var is parsed into `Config` (required some package test uplift)

### Additional Notes

Anything else we should know when reviewing?
