### PR TITLE
Time out to DD API after 10 seconds

### DIFF
--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -51,7 +51,7 @@ type (
 // MakeAPIClient creates a new API client with the given api and app keys
 func MakeAPIClient(ctx context.Context, options APIClientOptions) *APIClient {
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 5,
 	}
 	client := &APIClient{
 		apiKey:     options.apiKey,

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 )
@@ -49,7 +50,9 @@ type (
 
 // MakeAPIClient creates a new API client with the given api and app keys
 func MakeAPIClient(ctx context.Context, options APIClientOptions) *APIClient {
-	httpClient := &http.Client{}
+	httpClient := &http.Client{
+		Timeout: time.Second * 10,
+	}
 	client := &APIClient{
 		apiKey:     options.apiKey,
 		baseAPIURL: options.baseAPIURL,


### PR DESCRIPTION
### What does this PR do?

Set a ten second timeout on the `http.Client` used to communicate with the DataDog API.

### Motivation

The Go HTTP Client specifies no timeout by default, which means - theoretically - a request could hang indefinitely under unfortunate server conditions. This is especially unfortunate given this library is designed to run in Lambda, where execution time is money.

I chose 10 seconds somewhat arbitrarily. I'm open to other values, or even to making it tunable. My hope is that this PR will start a conversation, more than just being accepted. I have a poor understanding of what the Datadog API latency guarantees are around the globe.

### Testing Guidelines

I `go test`ed it. I also used it on a test lambda internally. It works exactly as expected under non-pathological cases.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
