### PR TITLE
adding configurable http client timeout

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -51,6 +51,8 @@ type (
 		DDTraceEnabled bool
 		// MergeXrayTraces will cause Datadog traces to be merged with traces from AWS X-Ray.
 		MergeXrayTraces bool
+		// HttpClientTimeout specifies a time limit for requests to the API. It defaults to 5s.
+		HttpClientTimeout time.Duration
 	}
 )
 
@@ -191,6 +193,7 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 		mc.KMSAPIKey = cfg.KMSAPIKey
 		mc.Site = cfg.Site
 		mc.ShouldUseLogForwarder = cfg.ShouldUseLogForwarder
+		mc.HttpClientTimeout = cfg.HttpClientTimeout
 	}
 
 	if mc.Site == "" {
@@ -227,6 +230,9 @@ func (cfg *Config) toMetricsConfig() metrics.Config {
 	}
 	if !mc.EnhancedMetrics {
 		mc.EnhancedMetrics = strings.EqualFold(enhancedMetrics, "true")
+	}
+	if mc.HttpClientTimeout <= 0 {
+		mc.HttpClientTimeout = time.Second * 5
 	}
 
 	return mc

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -37,10 +37,11 @@ type (
 
 	// APIClientOptions contains instantiation options from creating an APIClient.
 	APIClientOptions struct {
-		baseAPIURL string
-		apiKey     string
-		kmsAPIKey  string
-		decrypter  Decrypter
+		baseAPIURL        string
+		apiKey            string
+		kmsAPIKey         string
+		decrypter         Decrypter
+		httpClientTimeout time.Duration
 	}
 
 	postMetricsModel struct {
@@ -51,7 +52,7 @@ type (
 // MakeAPIClient creates a new API client with the given api and app keys
 func MakeAPIClient(ctx context.Context, options APIClientOptions) *APIClient {
 	httpClient := &http.Client{
-		Timeout: time.Second * 5,
+		Timeout: options.httpClientTimeout,
 	}
 	client := &APIClient{
 		apiKey:     options.apiKey,

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -45,6 +45,7 @@ type (
 		ShouldUseLogForwarder bool
 		BatchInterval         time.Duration
 		EnhancedMetrics       bool
+		HttpClientTimeout     time.Duration
 	}
 
 	logMetric struct {
@@ -66,11 +67,15 @@ const (
 func MakeListener(config Config) Listener {
 
 	apiClient := MakeAPIClient(context.Background(), APIClientOptions{
-		baseAPIURL: config.Site,
-		apiKey:     config.APIKey,
-		decrypter:  MakeKMSDecrypter(),
-		kmsAPIKey:  config.KMSAPIKey,
+		baseAPIURL:        config.Site,
+		apiKey:            config.APIKey,
+		decrypter:         MakeKMSDecrypter(),
+		kmsAPIKey:         config.KMSAPIKey,
+		httpClientTimeout: config.HttpClientTimeout,
 	})
+	if config.HttpClientTimeout <= 0 {
+		config.HttpClientTimeout = time.Second * 5
+	}
 	if config.BatchInterval <= 0 {
 		config.BatchInterval = defaultBatchInterval
 	}


### PR DESCRIPTION
### What does this PR do?

I'm adding the capability to configure the 5s timeout currently used.

I'm passing around the timeout variable from the user configuration to the place where it is used.

In a following PR, https://github.com/DataDog/datadog-lambda-go/pull/64 I'm adding also a circuit breaker so in case of hitting repeatedly the timeout,
your endpoint won't get called for a while.

### Motivation

We observed high latency at certain times and we would like to reduce the time and resources
it takes to resolve requests. This is related to support case 441237.

### Testing Guidelines

I changed the default timeout from 5s to a low number and observed the timeouts on the logs as errors.

### Additional Notes

This will be followed by a circuit breaker PR, to reduce the calls instead of the high latency situation happens again.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
