### PR TITLE
Disable tracer debug based on log level

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -175,11 +175,13 @@ func (cfg *Config) toTraceConfig() trace.Config {
 	traceConfig := trace.Config{
 		DDTraceEnabled:  false,
 		MergeXrayTraces: false,
+		DebugMode:       false,
 	}
 
 	if cfg != nil {
 		traceConfig.DDTraceEnabled = cfg.DDTraceEnabled
 		traceConfig.MergeXrayTraces = cfg.MergeXrayTraces
+		traceConfig.DebugMode = cfg.DebugLogging
 	}
 
 	if !traceConfig.DDTraceEnabled {
@@ -188,6 +190,11 @@ func (cfg *Config) toTraceConfig() trace.Config {
 
 	if !traceConfig.MergeXrayTraces {
 		traceConfig.MergeXrayTraces, _ = strconv.ParseBool(os.Getenv(MergeXrayTracesEnvVar))
+	}
+
+	if !traceConfig.DebugMode {
+		logLevel := os.Getenv(LogLevelEnvVar)
+		traceConfig.DebugMode = strings.EqualFold(logLevel, "debug")
 	}
 
 	return traceConfig

--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -26,12 +26,14 @@ type (
 	Listener struct {
 		ddTraceEnabled  bool
 		mergeXrayTraces bool
+		debugMode       bool
 	}
 
 	// Config gives options for how the Listener should work
 	Config struct {
 		DDTraceEnabled  bool
 		MergeXrayTraces bool
+		DebugMode       bool
 	}
 )
 
@@ -46,6 +48,7 @@ func MakeListener(config Config) Listener {
 	return Listener{
 		ddTraceEnabled:  config.DDTraceEnabled,
 		mergeXrayTraces: config.MergeXrayTraces,
+		debugMode:       config.DebugMode,
 	}
 }
 
@@ -61,7 +64,7 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 		tracer.Start(
 			tracer.WithService("aws.lambda"),
 			tracer.WithLambdaMode(true),
-			tracer.WithDebugMode(true),
+			tracer.WithDebugMode(l.debugMode),
 			tracer.WithGlobalTag("_dd.origin", "lambda"),
 		)
 		tracerInitialized = true


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Changes so that the started tracer does not enable debug mode unless the log level is set to `debug` through the `DD_LOG_LEVEL` environment variable, or debug logging is enabled through the configuration.

This _could_ be considered a breaking change as it changes the default of always enabling debug logging. 

### Motivation

The tracer prints a lot of `DEBUG` information when starting traces, which may not be desirable in all environments.

### Testing Guidelines

- Ran `go test ./...`
- Built an application using the library
  - Deployed in localstack with `DD_LOG_LEVEL=debug` 
  - Triggered lambda and verified I got DEBUG logs from the tracer
  - Removed `DD_LOG_LEVEL` from the lambda and verified DEBUG logs weren't present

### Additional Notes

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
