### PR TITLE
Change separateVersionFromFunctionArn function to check slice capacity before slicing

### DIFF
--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -127,6 +127,9 @@ func startFunctionExecutionSpan(ctx context.Context, mergeXrayTraces bool) trace
 
 func separateVersionFromFunctionArn(functionArn string) (arnWithoutVersion string, functionVersion string) {
 	arnSegments := strings.Split(functionArn, ":")
+	if cap(arnSegments) < 7 {
+		return "", ""
+	}
 	functionVersion = "$LATEST"
 	arnWithoutVersion = strings.Join(arnSegments[0:7], ":")
 	if len(arnSegments) > 7 {

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -39,6 +39,14 @@ func TestSeparateVersionFromFunctionArnWithoutVersion(t *testing.T) {
 	assert.Equal(t, expectedFunctionVersion, functionVersion)
 }
 
+func TestSeparateVersionFromFunctionArnEmptyString(t *testing.T) {
+	inputArn := ""
+
+	arnWithoutVersion, functionVersion := separateVersionFromFunctionArn(inputArn)
+	assert.Empty(t, arnWithoutVersion)
+	assert.Empty(t, functionVersion)
+}
+
 var traceContextFromXray = TraceContext{
 	traceIDHeader:  "1231452342",
 	parentIDHeader: "45678910",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
This pr changes the behavior of the `separateVersionFromFunctionArn` to check the capacity of the arnSegments slice before reslicing to avoid panics in case the slice capacity is not at least 7.

### Motivation

<!--- What inspired you to submit this pull request? --->
I was debugging a lambda function locally, so the LambdaContext object had an empty `InvokedFunctionArn` field. This caused the `separateVersionFromFunctionArn` to panic when reslicing `[0:7]` since the slice has capacity less than 7. As a result, my handler was never called.

### Testing Guidelines

<!--- How did you test this pull request? --->
I added a unit test. I also ran my code against this fork to verify the fix works. It works.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
