### PR TITLE
Try encrypting KMS key without encryption context first

### DIFF
--- a/internal/metrics/kms_decrypter.go
+++ b/internal/metrics/kms_decrypter.go
@@ -54,26 +54,25 @@ func decryptKMS(kmsClient kmsiface.KMSAPI, ciphertext string) (string, error) {
 		return "", fmt.Errorf("Failed to encode cipher text to base64: %v", err)
 	}
 
-	// The Lambda console UI changed the way it encrypts environment variables.
-	// The current behavior as of May 2021 is to encrypt environment variables using the function name as an encryption context.
-	// Previously, the behavior was to encrypt environment variables without an encryption context.
-	// We need to try both, as supplying the incorrect encryption context will cause decryption to fail.
+	// When the API key is encrypted using the AWS console, the function name is added as an
+	// encryption context. When the API key is encrypted using the AWS CLI, no encryption context
+	// is added. We need to try decrypting the API key both with and without the encryption context.
 
-	// Try with encryption context
+	// Try without encryption context, in case API key was encrypted using the AWS CLI
 	functionName := os.Getenv(functionNameEnvVar)
 	params := &kms.DecryptInput{
 		CiphertextBlob: decodedBytes,
-		EncryptionContext: map[string]*string{
-			encryptionContextKey: &functionName,
-		},
 	}
 	response, err := kmsClient.Decrypt(params)
 
 	if err != nil {
-		logger.Debug("Failed to decrypt ciphertext with encryption context, retrying without encryption context")
-		// Try without encryption context
+		logger.Debug("Failed to decrypt ciphertext without encryption context, retrying with encryption context")
+		// Try with encryption context, in case API key was encrypted using the AWS Console
 		params = &kms.DecryptInput{
 			CiphertextBlob: decodedBytes,
+			EncryptionContext: map[string]*string{
+				encryptionContextKey: &functionName,
+			},
 		}
 		response, err = kmsClient.Decrypt(params)
 		if err != nil {

--- a/internal/metrics/kms_decrypter_test.go
+++ b/internal/metrics/kms_decrypter_test.go
@@ -33,7 +33,11 @@ type mockKMSClientWithEncryptionContext struct {
 }
 
 func (mockKMSClientWithEncryptionContext) Decrypt(params *kms.DecryptInput) (*kms.DecryptOutput, error) {
-	if *params.EncryptionContext[encryptionContextKey] != mockFunctionName {
+	encryptionContextPointer, exists := params.EncryptionContext[encryptionContextKey]
+	if !exists {
+		return nil, errors.New("InvalidCiphertextExeption")
+	}
+	if *encryptionContextPointer != mockFunctionName {
 		return nil, errors.New("InvalidCiphertextExeption")
 	}
 	if bytes.Equal(params.CiphertextBlob, []byte(mockDecodedEncryptedAPIKey)) {

--- a/internal/metrics/kms_decrypter_test.go
+++ b/internal/metrics/kms_decrypter_test.go
@@ -35,10 +35,10 @@ type mockKMSClientWithEncryptionContext struct {
 func (mockKMSClientWithEncryptionContext) Decrypt(params *kms.DecryptInput) (*kms.DecryptOutput, error) {
 	encryptionContextPointer, exists := params.EncryptionContext[encryptionContextKey]
 	if !exists {
-		return nil, errors.New("InvalidCiphertextExeption")
+		return nil, errors.New("InvalidCiphertextException")
 	}
 	if *encryptionContextPointer != mockFunctionName {
-		return nil, errors.New("InvalidCiphertextExeption")
+		return nil, errors.New("InvalidCiphertextException")
 	}
 	if bytes.Equal(params.CiphertextBlob, []byte(mockDecodedEncryptedAPIKey)) {
 		return &kms.DecryptOutput{
@@ -54,7 +54,7 @@ type mockKMSClientNoEncryptionContext struct {
 
 func (mockKMSClientNoEncryptionContext) Decrypt(params *kms.DecryptInput) (*kms.DecryptOutput, error) {
 	if params.EncryptionContext[encryptionContextKey] != nil {
-		return nil, errors.New("InvalidCiphertextExeption")
+		return nil, errors.New("InvalidCiphertextException")
 	}
 	if bytes.Equal(params.CiphertextBlob, []byte(mockDecodedEncryptedAPIKey)) {
 		return &kms.DecryptOutput{


### PR DESCRIPTION
### What does this PR do?

When the API key is encrypted using the AWS console, the function name is added as an encryption context. When the API key is encrypted using the AWS CLI, no encryption context is added. We need to try decrypting the API key both with and without the encryption context, because decrypting using the incorrect encryption context will cause decryption to fail. 

Previously, we tried decrypting WITH the encryption context first, then fell back to encrypting WITHOUT the encryption context. This PR reverses the order and tries decrypting WITHOUT the encryption context first, falling back to encrypting WITH the encryption context.

### Motivation

We want to encourage customers to encrypt their keys using the AWS CLI, without the encryption context. That way, a single encrypted key can be re-used for multiple functions. This is necessary in order to use our deployment tools (e.g. Serverless Framework plugin).

### Testing Guidelines

We have unit test coverage of this functionality.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
