### PR TITLE
Add WrapHandlerInterface to support lambda.StartHandler

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -93,18 +93,25 @@ const (
 	DefaultEnhancedMetrics = true
 )
 
-// WrapWithCustomHandler is used to instrument your lambda functions.
+// WrapLambdaHandlerInterface is used to instrument your lambda functions.
 // It returns a modified handler that can be passed directly to the lambda.StartHandler function from aws-lambda-go.
-func WrapWithCustomHandler(handler lambda.Handler, cfg *Config) lambda.Handler {
+func WrapLambdaHandlerInterface(handler lambda.Handler, cfg *Config) lambda.Handler {
 	listeners := initializeListeners(cfg)
 	return wrapper.WrapHandlerInterfaceWithListeners(handler, listeners...)
 }
 
-// WrapHandler is used to instrument your lambda functions.
+// WrapFunction is used to instrument your lambda functions.
 // It returns a modified handler that can be passed directly to the lambda.Start function from aws-lambda-go.
-func WrapHandler(handler interface{}, cfg *Config) interface{} {
+func WrapFunction(handler interface{}, cfg *Config) interface{} {
 	listeners := initializeListeners(cfg)
 	return wrapper.WrapHandlerWithListeners(handler, listeners...)
+}
+
+// WrapHandler is used to instrument your lambda functions.
+// It returns a modified handler that can be passed directly to the lambda.Start function from aws-lambda-go.
+// Deprecated: use WrapFunction instead
+func WrapHandler(handler interface{}, cfg *Config) interface{} {
+	return WrapFunction(handler, cfg)
 }
 
 // GetTraceHeaders returns a map containing Datadog trace headers that reflect the

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -93,18 +93,17 @@ const (
 	DefaultEnhancedMetrics = true
 )
 
-// WrapHandlerInterface is used to instrument your lambda functions.
-// It returns a modified handler that can be passed directly to the lambda.StartHandler function.
-func WrapHandlerInterface(handler lambda.Handler, cfg *Config) lambda.Handler {
+// WrapWithCustomHandler is used to instrument your lambda functions.
+// It returns a modified handler that can be passed directly to the lambda.StartHandler function from aws-lambda-go.
+func WrapWithCustomHandler(handler lambda.Handler, cfg *Config) lambda.Handler {
 	listeners := initializeListeners(cfg)
 	return wrapper.WrapHandlerInterfaceWithListeners(handler, listeners...)
 }
 
 // WrapHandler is used to instrument your lambda functions.
-// It returns a modified handler that can be passed directly to the lambda. Start function.
+// It returns a modified handler that can be passed directly to the lambda.Start function from aws-lambda-go.
 func WrapHandler(handler interface{}, cfg *Config) interface{} {
 	listeners := initializeListeners(cfg)
-
 	return wrapper.WrapHandlerWithListeners(handler, listeners...)
 }
 

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -96,33 +96,16 @@ const (
 // WrapHandlerInterface is used to instrument your lambda functions.
 // It returns a modified handler that can be passed directly to the lambda.StartHandler function.
 func WrapHandlerInterface(handler lambda.Handler, cfg *Config) lambda.Handler {
-	logLevel := os.Getenv(LogLevelEnvVar)
-	if strings.EqualFold(logLevel, "debug") || (cfg != nil && cfg.DebugLogging) {
-		logger.SetLogLevel(logger.LevelDebug)
-	}
-	extensionManager := extension.BuildExtensionManager()
-
-	// Wrap the handler with listeners that add instrumentation for traces and metrics.
-	tl := trace.MakeListener(cfg.toTraceConfig(), extensionManager)
-	ml := metrics.MakeListener(cfg.toMetricsConfig(), extensionManager)
-	return wrapper.WrapHandlerInterfaceWithListeners(handler, &tl, &ml)
+	listeners := initializeListeners(cfg)
+	return wrapper.WrapHandlerInterfaceWithListeners(handler, listeners...)
 }
 
 // WrapHandler is used to instrument your lambda functions.
 // It returns a modified handler that can be passed directly to the lambda. Start function.
 func WrapHandler(handler interface{}, cfg *Config) interface{} {
+	listeners := initializeListeners(cfg)
 
-	logLevel := os.Getenv(LogLevelEnvVar)
-	if strings.EqualFold(logLevel, "debug") || (cfg != nil && cfg.DebugLogging) {
-		logger.SetLogLevel(logger.LevelDebug)
-	}
-
-	extensionManager := extension.BuildExtensionManager()
-
-	// Wrap the handler with listeners that add instrumentation for traces and metrics.
-	tl := trace.MakeListener(cfg.toTraceConfig(), extensionManager)
-	ml := metrics.MakeListener(cfg.toMetricsConfig(), extensionManager)
-	return wrapper.WrapHandlerWithListeners(handler, &tl, &ml)
+	return wrapper.WrapHandlerWithListeners(handler, listeners...)
 }
 
 // GetTraceHeaders returns a map containing Datadog trace headers that reflect the
@@ -210,6 +193,21 @@ func (cfg *Config) toTraceConfig() trace.Config {
 	}
 
 	return traceConfig
+}
+
+func initializeListeners(cfg *Config) []wrapper.HandlerListener {
+	logLevel := os.Getenv(LogLevelEnvVar)
+	if strings.EqualFold(logLevel, "debug") || (cfg != nil && cfg.DebugLogging) {
+		logger.SetLogLevel(logger.LevelDebug)
+	}
+	extensionManager := extension.BuildExtensionManager()
+
+	// Wrap the handler with listeners that add instrumentation for traces and metrics.
+	tl := trace.MakeListener(cfg.toTraceConfig(), extensionManager)
+	ml := metrics.MakeListener(cfg.toMetricsConfig(), extensionManager)
+	return []wrapper.HandlerListener{
+		&tl, &ml,
+	}
 }
 
 func (cfg *Config) toMetricsConfig() metrics.Config {

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-lambda-go/internal/metrics"
 	"github.com/DataDog/datadog-lambda-go/internal/trace"
 	"github.com/DataDog/datadog-lambda-go/internal/wrapper"
+	"github.com/aws/aws-lambda-go/lambda"
 )
 
 type (
@@ -91,6 +92,21 @@ const (
 	// DefaultEnhancedMetrics enables enhanced metrics by default.
 	DefaultEnhancedMetrics = true
 )
+
+// WrapHandlerInterface is used to instrument your lambda functions.
+// It returns a modified handler that can be passed directly to the lambda.StartHandler function.
+func WrapHandlerInterface(handler lambda.Handler, cfg *Config) lambda.Handler {
+	logLevel := os.Getenv(LogLevelEnvVar)
+	if strings.EqualFold(logLevel, "debug") || (cfg != nil && cfg.DebugLogging) {
+		logger.SetLogLevel(logger.LevelDebug)
+	}
+	extensionManager := extension.BuildExtensionManager()
+
+	// Wrap the handler with listeners that add instrumentation for traces and metrics.
+	tl := trace.MakeListener(cfg.toTraceConfig(), extensionManager)
+	ml := metrics.MakeListener(cfg.toMetricsConfig(), extensionManager)
+	return wrapper.WrapHandlerInterfaceWithListeners(handler, &tl, &ml)
+}
 
 // WrapHandler is used to instrument your lambda functions.
 // It returns a modified handler that can be passed directly to the lambda. Start function.

--- a/internal/wrapper/wrap_handler.go
+++ b/internal/wrapper/wrap_handler.go
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 package wrapper

--- a/internal/wrapper/wrap_handler_test.go
+++ b/internal/wrapper/wrap_handler_test.go
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 package wrapper


### PR DESCRIPTION
### What does this PR do?

Adds support for lambda.StartHandler, via a new method WrapHandlerInterface

### Motivation

#72 

### Testing Guidelines

The new code is covered by unit tests.

### Additional Notes


### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
