### PR TITLE
Set default sampling priority to sampler-keep

### DIFF
--- a/internal/testdata/non-proxy-with-missing-sampling-priority.json
+++ b/internal/testdata/non-proxy-with-missing-sampling-priority.json
@@ -1,0 +1,10 @@
+{
+  "my-custom-event": {
+    "hello": 100
+  },
+  "fake-id": "12345678910",
+  "headers": {
+    "X-Datadog-Trace-Id": "1231452342",
+    "X-Datadog-Parent-Id": "45678910"
+  }
+}

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -148,7 +148,7 @@ func getDatadogTraceContextFromEvent(ctx context.Context, ev json.RawMessage) (T
 
 	samplingPriority, ok := lowercaseHeaders[samplingPriorityHeader]
 	if !ok {
-		return traceCtx, false
+		samplingPriority = "1" //sampler-keep
 	}
 
 	traceCtx[samplingPriorityHeader] = samplingPriority

--- a/internal/trace/context_test.go
+++ b/internal/trace/context_test.go
@@ -84,6 +84,21 @@ func TestGetDatadogTraceContextForTraceMetadataWithMixedCaseHeaders(t *testing.T
 	assert.Equal(t, expected, headers)
 }
 
+func TestGetDatadogTraceContextForTraceMetadataWithMissingSamplingPriority(t *testing.T) {
+	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
+	ev := loadRawJSON(t, "../testdata/non-proxy-with-missing-sampling-priority.json")
+
+	headers, ok := getDatadogTraceContextFromEvent(ctx, *ev)
+	assert.True(t, ok)
+
+	expected := TraceContext{
+		traceIDHeader:          "1231452342",
+		parentIDHeader:         "45678910",
+		samplingPriorityHeader: "1",
+	}
+	assert.Equal(t, expected, headers)
+}
+
 func TestGetDatadogTraceContextForInvalidData(t *testing.T) {
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/invalid.json")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes #74. If datadog-lambda-go comes across a trace that does not have sampling-priority set, it should set a default priority (I think Tian decided on sampler-keep, but I will confirm.) This matches the behavior of other datadog-lambda-* libraries.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
