### PR TITLE
[SLS-1260] Add functionname attribute to span metadata

### DIFF
--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -116,6 +116,7 @@ func startFunctionExecutionSpan(ctx context.Context, mergeXrayTraces bool) trace
 		tracer.Tag("function_version", functionVersion),
 		tracer.Tag("request_id", lambdaCtx.AwsRequestID),
 		tracer.Tag("resource_names", lambdacontext.FunctionName),
+		tracer.Tag("functionname", strings.ToLower(lambdacontext.FunctionName)),
 		tracer.Tag("datadog_lambda", version.DDLambdaVersion),
 		tracer.Tag("dd_trace", version.DDTraceVersion),
 	)

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -86,6 +86,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeEnabled(t *testing.T) {
 	assert.Equal(t, "abcdefgh-1234-5678-1234-abcdefghijkl", finishedSpan.Tag("request_id"))
 	assert.Equal(t, "MockFunctionName", finishedSpan.Tag("resource.name"))
 	assert.Equal(t, "MockFunctionName", finishedSpan.Tag("resource_names"))
+	assert.Equal(t, "mockfunctionname", finishedSpan.Tag("functionname"))
 	assert.Equal(t, "serverless", finishedSpan.Tag("span.type"))
 	assert.Equal(t, "xray", finishedSpan.Tag("_dd.parent_source"))
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-js/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Add the `functionname` attribute to the Lambda span metadata. 

### Motivation

<!--- What inspired you to submit this pull request? --->
Look at problem 2 here: https://docs.google.com/document/d/1Jd40XCKibvhVntIiT02xjaZZlq3P2ohRHZ8VnKtu46Q/edit#

### Testing Guidelines

<!--- How did you test this pull request? --->
Check the trace metadata tags to ensure the `functionname` attribute is present.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)