### PR TITLE
Support secret arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,28 @@ A more complete example can be found in the `ddlambda_example_test.go` file.
 
 ### DD_FLUSH_TO_LOG
 
-Set to `true` (recommended) to send custom metrics asynchronously (with no added latency to your Lambda function executions) through CloudWatch Logs with the help of [Datadog Forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring). Defaults to `false`. If set to `false`, you also need to set `DD_API_KEY` and `DD_SITE`.
+Set to `true` (recommended) to send custom metrics asynchronously (with no added latency to your Lambda function executions) through CloudWatch Logs with the help of [Datadog Forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring). Defaults to `false`. If set to `false`, you also need to set `DD_SITE` and one of the
+following `DD_API_KEY`, `DD_KMS_API_KEY` or `DD_API_KEY_SECRET_ARN`.
 
 ### DD_API_KEY
 
-If `DD_FLUSH_TO_LOG` is set to `false` (not recommended), the Datadog API Key must be defined.
+If `DD_FLUSH_TO_LOG` is set to `false` (not recommended), the Datadog API key must be
+set to `DD_API_KEY`, or either `DD_KMS_API_KEY` or `DD_API_KEY_SECRET_ARN` below must
+be defined instead.
+
+### DD_KMS_API_KEY
+
+If `DD_FLUSH_TO_LOG` is set to `false` (not recommended) and `DD_API_KEY` is not set,
+the Datadog API key encrypted using the AWS Key Management Service (KMS) must be set to
+`DD_KMS_API_KEY`, or the following `DD_API_KEY_SECRET_ARN` must be defined instead.
+The encryption key used to encrypt the API key must be a symmetric KMS key.
+
+### DD_API_KEY_SECRET_ARN
+
+If `DD_FLUSH_TO_LOG` is set to `false` (not recommended) and neither `DD_API_KEY` nor
+`DD_KMS_API_KEY` is set, the ARN of an AWS Secrets Manager secret where the Datadog API
+key is stored must be set to `DD_API_KEY_SECRET_ARN`. The secret value must be just the
+API key string itself (no double quotes), not a JSON object.
 
 ### DD_SITE
 

--- a/internal/metrics/kms_decrypter.go
+++ b/internal/metrics/kms_decrypter.go
@@ -13,7 +13,7 @@ import (
 	"os"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
 )
@@ -35,10 +35,10 @@ const functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
 // encryptionContextKey is the key added to the encryption context by the Lambda console UI
 const encryptionContextKey = "LambdaFunctionName"
 
-// MakeKMSDecrypter creates a new decrypter which uses the AWS KMS service to decrypt variables
-func MakeKMSDecrypter() Decrypter {
+// MakeKMSDecrypter creates a new decrypter which uses the AWS KMS service to decrypt variables.
+func MakeKMSDecrypter(p client.ConfigProvider) Decrypter {
 	return &kmsDecrypter{
-		kmsClient: kms.New(session.New(nil)),
+		kmsClient: kms.New(p),
 	}
 }
 

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -40,6 +40,7 @@ type (
 	Config struct {
 		APIKey                      string
 		KMSAPIKey                   string
+		APIKeySecretARN             string
 		Site                        string
 		ShouldRetryOnFailure        bool
 		ShouldUseLogForwarder       bool
@@ -67,6 +68,8 @@ func MakeListener(config Config, extensionManager *extension.ExtensionManager) L
 		apiKey:            config.APIKey,
 		decrypter:         MakeKMSDecrypter(),
 		kmsAPIKey:         config.KMSAPIKey,
+		secretFetcher:     MakeSecretsManagerSecretFetcher(),
+		apiKeySecretARN:   config.APIKeySecretARN,
 		httpClientTimeout: config.HttpClientTimeout,
 	})
 	if config.HttpClientTimeout <= 0 {

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/lambdacontext"
+	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/DataDog/datadog-lambda-go/internal/extension"
@@ -62,13 +63,13 @@ type (
 
 // MakeListener initializes a new metrics lambda listener
 func MakeListener(config Config, extensionManager *extension.ExtensionManager) Listener {
-
+	sess := session.Must(session.NewSession())
 	apiClient := MakeAPIClient(context.Background(), APIClientOptions{
 		baseAPIURL:        config.Site,
 		apiKey:            config.APIKey,
-		decrypter:         MakeKMSDecrypter(),
+		decrypter:         MakeKMSDecrypter(sess),
 		kmsAPIKey:         config.KMSAPIKey,
-		secretFetcher:     MakeSecretsManagerSecretFetcher(),
+		secretFetcher:     MakeSecretsManagerSecretFetcher(sess),
 		apiKeySecretARN:   config.APIKeySecretARN,
 		httpClientTimeout: config.HttpClientTimeout,
 	})

--- a/internal/metrics/secret_fetcher.go
+++ b/internal/metrics/secret_fetcher.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package metrics
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-lambda-go/internal/logger"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+)
+
+// SecretFetcher attempts to fetch a secret.
+type SecretFetcher interface {
+	FetchSecret(secretID string) (string, error)
+}
+
+// secretsManagerSecretFether fetches a secret from AWS Secrets Manager.
+type secretsManagerSecretFether struct {
+	client secretsmanageriface.SecretsManagerAPI
+}
+
+// MakeSecretsManagerSecretFetcher creates a new SecretFetcher which uses the AWS
+// Secrets Manager service to fetch a secret.
+func MakeSecretsManagerSecretFetcher() SecretFetcher {
+	return &secretsManagerSecretFether{
+		client: secretsmanager.New(session.Must(session.NewSession())),
+	}
+}
+
+// FetchSecret fetches and returns a secret for a given secret ID.
+func (sf *secretsManagerSecretFether) FetchSecret(secretID string) (string, error) {
+	logger.Debug("Fetching Secrets Manager secret " + secretID)
+	output, err := sf.client.GetSecretValue(&secretsmanager.GetSecretValueInput{
+		SecretId: &secretID,
+	})
+	if err != nil {
+		return "", fmt.Errorf(
+			"could not retrieve Secrets Manager secret %q: %s", secretID, err,
+		)
+	}
+
+	if s := output.SecretString; s != nil {
+		return *s, nil
+	}
+
+	if b := output.SecretBinary; b != nil {
+		// SecretBinary field has been automatically base64 decoded by the AWS SDK
+		return string(b), nil
+	}
+
+	// Should not happen but let's handle this gracefully
+	logger.Error(errors.New(
+		"Secrets Manager returned something but there seems to be no data available",
+	))
+	return "", nil
+}

--- a/internal/metrics/secret_fetcher.go
+++ b/internal/metrics/secret_fetcher.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
-	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 )
@@ -26,9 +26,9 @@ type secretsManagerSecretFether struct {
 
 // MakeSecretsManagerSecretFetcher creates a new SecretFetcher which uses the AWS
 // Secrets Manager service to fetch a secret.
-func MakeSecretsManagerSecretFetcher() SecretFetcher {
+func MakeSecretsManagerSecretFetcher(p client.ConfigProvider) SecretFetcher {
 	return &secretsManagerSecretFether{
-		client: secretsmanager.New(session.Must(session.NewSession())),
+		client: secretsmanager.New(p),
 	}
 }
 

--- a/internal/metrics/secret_fetcher_test.go
+++ b/internal/metrics/secret_fetcher_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package metrics
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSecretsManagerClient struct {
+	secretsmanageriface.SecretsManagerAPI
+
+	secretString string
+	secretBinary []byte
+}
+
+func (c mockSecretsManagerClient) GetSecretValue(
+	input *secretsmanager.GetSecretValueInput,
+) (*secretsmanager.GetSecretValueOutput, error) {
+	out := &secretsmanager.GetSecretValueOutput{SecretBinary: c.secretBinary}
+	if c.secretString != "" {
+		out.SecretString = &c.secretString
+	}
+	return out, nil
+}
+
+func TestSecretsManagerSecretsFetcher(t *testing.T) {
+	tests := map[string]struct {
+		client mockSecretsManagerClient
+		want   string
+	}{
+		"secret is string": {
+			client: mockSecretsManagerClient{secretString: "3333333333"},
+			want:   "3333333333",
+		},
+		"secret is binary": {
+			client: mockSecretsManagerClient{secretBinary: []byte("4444444444")},
+			want:   "4444444444",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			fetcher := &secretsManagerSecretFether{client: tt.client}
+			got, err := fetcher.FetchSecret(
+				"arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
+			)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Adds support for `DD_API_KEY_SECRET_ARN` environment variable.

### Motivation

<!--- What inspired you to submit this pull request? --->

When using the Datadog Lambda Extension for Lambda APM, it is necessary to set the API key to an environment variable, but it is not secure to set the API key in plain text to `DD_API_KEY`.
I use `DD_KMS_API_KEY` for this reason, but I felt it was very troublesome to have to encrypt the key using KMS.

I looked at [Serverless Agent](https://github.com/DataDog/datadog-agent/tree/main/cmd/serverless) and found that it also supports `DD_API_KEY_SECRET_ARN`, which I think would be very useful.
I also saw #98 and knew that there were others with similar needs.

So I wanted to add support for `DD_API_KEY_SECRET_ARN` to this library.
I believe this feature would be very beneficial to Datadog users who use the Lambda Extension.

### Testing Guidelines

<!--- How did you test this pull request? --->

I first tagged this working branch in my forked repository, added a `replace` directive to `go.mod` for our microservice that uses this library so that it uses my forked repository instead, and built the Go binary.

I then set `DD_API_KEY_SECRET_ARN` instead of `DD_KMS_API_KEY` to environment variables for the microservice's Lambda function, and deployed the binary to Lambda.

Finally, I ran this Lambda function and confirmed that metrics and traces were sent to Datadog as expected.
I also confirmed that the debug logs I added were output on CloudWatch Logs.

I strongly felt that not having to set the API key (even if it is encrypted) directly to an environment variable is a very good user experience.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

I also added an explanation for `DD_KMS_API_KEY` and `DD_API_KEY_SECRET_ARN` to README, but I'm not sure if this explanation is clear enough for users, so if you have any idea to improve it, I would appreciate your idea.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
