### PR TITLE
Do not show error messages even if neither `DD_API_KEY` nor `DD_KMS_API_KEY` is set when Lambda Extension is running

### DIFF
--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -106,9 +106,14 @@ func MakeListener(config Config, extensionManager *extension.ExtensionManager) L
 	}
 }
 
+// canSendMetrics reports whether l can send metrics.
+func (l *Listener) canSendMetrics() bool {
+	return l.isAgentRunning || l.apiClient.apiKey != "" || l.config.KMSAPIKey != "" || l.config.ShouldUseLogForwarder
+}
+
 // HandlerStarted adds metrics service to the context
 func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) context.Context {
-	if l.apiClient.apiKey == "" && l.config.KMSAPIKey == "" && !l.config.ShouldUseLogForwarder {
+	if !l.canSendMetrics() {
 		logger.Error(fmt.Errorf("datadog api key isn't set, won't be able to send metrics"))
 	}
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

When the Datadog Lambda Extension is running, do not show error messages even if neither `DD_API_KEY` nor `DD_KMS_API_KEY` is set.

### Motivation

<!--- What inspired you to submit this pull request? --->

In #101, it became clear that when the Datadog Lambda Extension is running, this library does not require either `DD_API_KEY` or `DD_KMS_API_KEY`.

Therefore, when the Extension is running, even if neither `DD_API_KEY` nor `DD_KMS_API_KEY` is set, error messages should not appear.

### Testing Guidelines

<!--- How did you test this pull request? --->

Same as #101. No error messages were shown even though neither `DD_API_KEY` nor `DD_KMS_API_KEY` was set 👍

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
