### PR TITLE
add DD_ENV and DD_SERVICE env vars to dd lambda tracer

### DIFF
--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -157,7 +157,7 @@ func (l *Listener) buildTraceStartOptions() []tracer.StartOption {
 
 	ddEnv := os.Getenv("DD_ENV")
 	if ddEnv != "" {
-		tracerStartOptions = append(tracerStartOptions, tracer.WithService(ddEnv))
+		tracerStartOptions = append(tracerStartOptions, tracer.WithEnv(ddEnv))
 	}
 
 	return tracerStartOptions

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -167,6 +167,8 @@ func TestListener_buildTraceStartOptions(t *testing.T) {
 		customServiceName := "my-service"
 
 		os.Setenv("DD_SERVICE", customServiceName)
+		defer os.Unsetenv("DD_SERVICE")
+
 		os.Unsetenv("DD_ENV")
 
 		listener := Listener{extensionManager: &extension.ExtensionManager{}}
@@ -181,6 +183,7 @@ func TestListener_buildTraceStartOptions(t *testing.T) {
 
 		os.Unsetenv("DD_SERVICE")
 		os.Setenv("DD_ENV", customEnvName)
+		defer os.Unsetenv("DD_ENV")
 
 		listener := Listener{extensionManager: &extension.ExtensionManager{}}
 
@@ -194,7 +197,10 @@ func TestListener_buildTraceStartOptions(t *testing.T) {
 		customServiceName := "my-service"
 
 		os.Setenv("DD_SERVICE", customServiceName)
+		defer os.Unsetenv("DD_SERVICE")
+
 		os.Setenv("DD_ENV", customEnvName)
+		defer os.Unsetenv("DD_ENV")
 
 		listener := Listener{extensionManager: &extension.ExtensionManager{}}
 


### PR DESCRIPTION
### What does this PR do?

In my company, we need a different trace name for lambda staging environment, and each service. 
So, my suggestion is to add two new environment variable, that already been in the documentation of ddtrace, and replace in the start of lambda.

The env is none if not set.
The service is always "aws-lambdas" as fallback.

The documentation that inspired me with this env names was: https://ddtrace.readthedocs.io/en/stable/configuration.html

![image](https://user-images.githubusercontent.com/17145198/171515960-35c431bb-e5a3-46ab-813f-59ba7551efe3.png)

### Testing Guidelines

Sets the environment variables `DD_ENV` and `DD_SERVICE` and check if the tracers are equals one.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [X] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
