### PR TITLE
[SLS-2330] Add support for universal instrumentation with the extension

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -220,12 +220,14 @@ func initializeListeners(cfg *Config) []wrapper.HandlerListener {
 	if strings.EqualFold(logLevel, "debug") || (cfg != nil && cfg.DebugLogging) {
 		logger.SetLogLevel(logger.LevelDebug)
 	}
-	extensionManager := extension.BuildExtensionManager()
+	traceConfig := cfg.toTraceConfig()
+	extensionManager := extension.BuildExtensionManager(traceConfig.UniversalInstrumentation)
 	isExtensionRunning := extensionManager.IsExtensionRunning()
+	metricsConfig := cfg.toMetricsConfig(isExtensionRunning)
 
 	// Wrap the handler with listeners that add instrumentation for traces and metrics.
-	tl := trace.MakeListener(cfg.toTraceConfig(), extensionManager)
-	ml := metrics.MakeListener(cfg.toMetricsConfig(isExtensionRunning), extensionManager)
+	tl := trace.MakeListener(traceConfig, extensionManager)
+	ml := metrics.MakeListener(metricsConfig, extensionManager)
 	return []wrapper.HandlerListener{
 		&tl, &ml,
 	}

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -89,6 +89,8 @@ const (
 	DatadogTraceEnabledEnvVar = "DD_TRACE_ENABLED"
 	// MergeXrayTracesEnvVar is the environment variable that enables the merging of X-Ray and Datadog traces.
 	MergeXrayTracesEnvVar = "DD_MERGE_XRAY_TRACES"
+	// UniversalInstrumentation is the environment variable that enables universal instrumentation with the DD Extension
+	UniversalInstrumentation = "DD_UNIVERSAL_INSTRUMENTATION"
 
 	// DefaultSite to send API messages to.
 	DefaultSite = "datadoghq.com"
@@ -183,8 +185,9 @@ func InvokeDryRun(callback func(ctx context.Context), cfg *Config) (interface{},
 
 func (cfg *Config) toTraceConfig() trace.Config {
 	traceConfig := trace.Config{
-		DDTraceEnabled:  false,
-		MergeXrayTraces: false,
+		DDTraceEnabled:           false,
+		MergeXrayTraces:          false,
+		UniversalInstrumentation: false,
 	}
 
 	if cfg != nil {
@@ -203,6 +206,10 @@ func (cfg *Config) toTraceConfig() trace.Config {
 
 	if !traceConfig.MergeXrayTraces {
 		traceConfig.MergeXrayTraces, _ = strconv.ParseBool(os.Getenv(MergeXrayTracesEnvVar))
+	}
+
+	if !traceConfig.UniversalInstrumentation {
+		traceConfig.UniversalInstrumentation, _ = strconv.ParseBool(os.Getenv(UniversalInstrumentation))
 	}
 
 	return traceConfig

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -141,7 +141,7 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 	}
 
 	resp, err := em.httpClient.Do(req)
-	if err != nil || (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
+	if err != nil || resp.StatusCode != 200 {
 		logger.Error(fmt.Errorf("could not send end invocation payload to the extension: %v", err))
 	}
 }

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -109,7 +109,7 @@ func (em *ExtensionManager) SendStartInvocationRequest(ctx context.Context, even
 
 func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functionExecutionSpan ddtrace.Span, err error) {
 	// Handle Lambda response
-	lambdaResponse, ok := ctx.Value(DdLambdaResponse).([]byte)
+	lambdaResponse, ok := ctx.Value(DdLambdaResponse).(interface{})
 	content, _ := json.Marshal(lambdaResponse)
 	if !ok {
 		content, _ = json.Marshal("{}")

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
@@ -82,6 +83,15 @@ func (em *ExtensionManager) checkAgentRunning() {
 	} else {
 		logger.Debug("Will use the Serverless Agent")
 		em.isExtensionRunning = true
+
+		// Tell the extension not to create an execution span if universal instrumentation is disabled
+		isUniversalInstrumentation, _ := strconv.ParseBool(os.Getenv("DD_UNIVERSAL_INSTRUMENTATION"))
+		if !isUniversalInstrumentation {
+			req, _ := http.NewRequest(http.MethodGet, em.helloRoute, nil)
+			if response, err := em.httpClient.Do(req); err == nil && response.StatusCode == 200 {
+				logger.Debug("Hit the extension /hello route")
+			}
+		}
 	}
 }
 

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -91,17 +91,17 @@ func (em *ExtensionManager) SendStartInvocationRequest(ctx context.Context, even
 
 	if response, err := em.httpClient.Do(req); err == nil && response.StatusCode == 200 {
 		// Propagate dd-trace context from the extension response if found in the response headers
-		traceId := response.Header.Values(string(DdTraceId))
-		if len(traceId) > 0 {
-			ctx = context.WithValue(ctx, DdTraceId, traceId[0])
+		traceId := response.Header.Get(string(DdTraceId))
+		if traceId != "" {
+			ctx = context.WithValue(ctx, DdTraceId, traceId)
 		}
-		parentId := response.Header.Values(string(DdParentId))
-		if len(parentId) > 0 {
-			ctx = context.WithValue(ctx, DdParentId, parentId[0])
+		parentId := response.Header.Get(string(DdParentId))
+		if parentId != "" {
+			ctx = context.WithValue(ctx, DdParentId, parentId)
 		}
-		samplingPriority := response.Header.Values(string(DdSamplingPriority))
-		if len(samplingPriority) > 0 {
-			ctx = context.WithValue(ctx, DdSamplingPriority, samplingPriority[0])
+		samplingPriority := response.Header.Get(string(DdSamplingPriority))
+		if samplingPriority != "" {
+			ctx = context.WithValue(ctx, DdSamplingPriority, samplingPriority)
 		}
 	}
 	return ctx

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -115,8 +115,6 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 		content = []byte("{}")
 	}
 	body := bytes.NewBuffer(content)
-
-	// Build the request
 	req, _ := http.NewRequest(http.MethodPost, em.endInvocationUrl, body)
 
 	// Mark the invocation as an error if any
@@ -142,9 +140,9 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 		req.Header.Set(string(DdSpanId), fmt.Sprint(functionExecutionSpan.Context().SpanID()))
 	}
 
-	response, err := em.httpClient.Do(req)
-	if response.StatusCode != 200 || err != nil {
-		logger.Debug("Unable to make a request to the extension's end invocation endpoint")
+	resp, err := em.httpClient.Do(req)
+	if err != nil || (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
+		logger.Error(fmt.Errorf("could not send end invocation payload to the extension"))
 	}
 }
 

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -9,12 +9,29 @@
 package extension
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+)
+
+type ddTraceContext string
+
+const (
+	DdTraceId          ddTraceContext = "x-datadog-trace-id"
+	DdParentId         ddTraceContext = "x-datadog-parent-id"
+	DdSpanId           ddTraceContext = "x-datadog-span-id"
+	DdSamplingPriority ddTraceContext = "x-datadog-sampling-priority"
+	DdInvocationError  ddTraceContext = "x-datadog-invocation-error"
+
+	DdSeverlessSpan  ddTraceContext = "dd-tracer-serverless-span"
+	DdLambdaResponse ddTraceContext = "dd-response"
 )
 
 const (
@@ -23,8 +40,10 @@ const (
 	// want to let it having some time for its cold start so we should not set this too low.
 	timeout = 3000 * time.Millisecond
 
-	helloUrl = "http://localhost:8124/lambda/hello"
-	flushUrl = "http://localhost:8124/lambda/flush"
+	helloUrl           = "http://localhost:8124/lambda/hello"
+	flushUrl           = "http://localhost:8124/lambda/flush"
+	startInvocationUrl = "http://localhost:8124/lambda/start-invocation"
+	endInvocationUrl   = "http://localhost:8124/lambda/end-invocation"
 
 	extensionPath = "/opt/extensions/datadog-agent"
 )
@@ -33,6 +52,8 @@ type ExtensionManager struct {
 	helloRoute         string
 	flushRoute         string
 	extensionPath      string
+	startInvocationUrl string
+	endInvocationUrl   string
 	httpClient         HTTPClient
 	isExtensionRunning bool
 }
@@ -43,10 +64,12 @@ type HTTPClient interface {
 
 func BuildExtensionManager() *ExtensionManager {
 	em := &ExtensionManager{
-		helloRoute:    helloUrl,
-		flushRoute:    flushUrl,
-		extensionPath: extensionPath,
-		httpClient:    &http.Client{Timeout: timeout},
+		helloRoute:         helloUrl,
+		flushRoute:         flushUrl,
+		startInvocationUrl: startInvocationUrl,
+		endInvocationUrl:   endInvocationUrl,
+		extensionPath:      extensionPath,
+		httpClient:         &http.Client{Timeout: timeout},
 	}
 	em.checkAgentRunning()
 	return em
@@ -57,14 +80,71 @@ func (em *ExtensionManager) checkAgentRunning() {
 		logger.Debug("Will use the API")
 		em.isExtensionRunning = false
 	} else {
-		req, _ := http.NewRequest(http.MethodGet, em.helloRoute, nil)
-		if response, err := em.httpClient.Do(req); err == nil && response.StatusCode == 200 {
-			logger.Debug("Will use the Serverless Agent")
-			em.isExtensionRunning = true
-		} else {
-			logger.Debug("Will use the API since the Serverless Agent was detected but the hello route was unreachable")
-			em.isExtensionRunning = false
+		logger.Debug("Will use the Serverless Agent")
+		em.isExtensionRunning = true
+	}
+}
+
+func (em *ExtensionManager) SendStartInvocationRequest(ctx context.Context, eventPayload json.RawMessage) context.Context {
+	body := bytes.NewBuffer(eventPayload)
+	req, _ := http.NewRequest(http.MethodPost, em.startInvocationUrl, body)
+
+	if response, err := em.httpClient.Do(req); err == nil && response.StatusCode == 200 {
+		// Propagate dd-trace context from the extension response if found in the response headers
+		traceId := response.Header.Values(string(DdTraceId))
+		if len(traceId) > 0 {
+			ctx = context.WithValue(ctx, DdTraceId, traceId[0])
 		}
+		parentId := response.Header.Values(string(DdParentId))
+		if len(parentId) > 0 {
+			ctx = context.WithValue(ctx, DdParentId, parentId[0])
+		}
+		samplingPriority := response.Header.Values(string(DdSamplingPriority))
+		if len(samplingPriority) > 0 {
+			ctx = context.WithValue(ctx, DdSamplingPriority, samplingPriority[0])
+		}
+	}
+	return ctx
+}
+
+func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functionExecutionSpan ddtrace.Span, err error) {
+	// Handle Lambda response
+	lambdaResponse, ok := ctx.Value(DdLambdaResponse).([]byte)
+	content, _ := json.Marshal(lambdaResponse)
+	if !ok {
+		content, _ = json.Marshal("{}")
+	}
+	body := bytes.NewBuffer(content)
+
+	// Build the request
+	req, _ := http.NewRequest(http.MethodPost, em.endInvocationUrl, body)
+
+	// Mark the invocation as an error if any
+	if err != nil {
+		req.Header[string(DdInvocationError)] = append(req.Header[string(DdInvocationError)], "true")
+	}
+
+	// Extract the DD trace context and pass them to the extension via request headers
+	traceId, ok := ctx.Value(DdTraceId).(string)
+	if ok {
+		req.Header[string(DdTraceId)] = append(req.Header[string(DdTraceId)], traceId)
+		if parentId, ok := ctx.Value(DdParentId).(string); ok {
+			req.Header[string(DdParentId)] = append(req.Header[string(DdParentId)], parentId)
+		}
+		if spanId, ok := ctx.Value(DdSpanId).(string); ok {
+			req.Header[string(DdSpanId)] = append(req.Header[string(DdSpanId)], spanId)
+		}
+		if samplingPriority, ok := ctx.Value(DdSamplingPriority).(string); ok {
+			req.Header[string(DdSamplingPriority)] = append(req.Header[string(DdSamplingPriority)], samplingPriority)
+		}
+	} else {
+		req.Header[string(DdTraceId)] = append(req.Header[string(DdTraceId)], fmt.Sprint(functionExecutionSpan.Context().TraceID()))
+		req.Header[string(DdSpanId)] = append(req.Header[string(DdSpanId)], fmt.Sprint(functionExecutionSpan.Context().SpanID()))
+	}
+
+	response, err := em.httpClient.Do(req)
+	if response.StatusCode != 200 || err != nil {
+		logger.Debug("Unable to make a request to the extension's end invocation endpoint")
 	}
 }
 

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -109,9 +109,9 @@ func (em *ExtensionManager) SendStartInvocationRequest(ctx context.Context, even
 
 func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functionExecutionSpan ddtrace.Span, err error) {
 	// Handle Lambda response
-	lambdaResponse, ok := ctx.Value(DdLambdaResponse).(interface{})
-	content, _ := json.Marshal(lambdaResponse)
-	if !ok {
+	lambdaResponse := ctx.Value(DdLambdaResponse)
+	content, responseErr := json.Marshal(lambdaResponse)
+	if responseErr != nil {
 		content, _ = json.Marshal("{}")
 	}
 	body := bytes.NewBuffer(content)

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -142,7 +142,7 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 
 	resp, err := em.httpClient.Do(req)
 	if err != nil || (resp.StatusCode >= 200 && resp.StatusCode <= 299) {
-		logger.Error(fmt.Errorf("could not send end invocation payload to the extension"))
+		logger.Error(fmt.Errorf("could not send end invocation payload to the extension: %v", err))
 	}
 }
 

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -91,6 +91,9 @@ func (em *ExtensionManager) checkAgentRunning() {
 			req, _ := http.NewRequest(http.MethodGet, em.helloRoute, nil)
 			if response, err := em.httpClient.Do(req); err == nil && response.StatusCode == 200 {
 				logger.Debug("Hit the extension /hello route")
+			} else {
+				logger.Debug("Will use the API since the Serverless Agent was detected but the hello route was unreachable")
+				em.isExtensionRunning = false
 			}
 		}
 	}

--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -112,7 +112,7 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 	lambdaResponse := ctx.Value(DdLambdaResponse)
 	content, responseErr := json.Marshal(lambdaResponse)
 	if responseErr != nil {
-		content, _ = json.Marshal("{}")
+		content = []byte("{}")
 	}
 	body := bytes.NewBuffer(content)
 
@@ -121,25 +121,25 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 
 	// Mark the invocation as an error if any
 	if err != nil {
-		req.Header[string(DdInvocationError)] = append(req.Header[string(DdInvocationError)], "true")
+		req.Header.Set(string(DdInvocationError), "true")
 	}
 
 	// Extract the DD trace context and pass them to the extension via request headers
 	traceId, ok := ctx.Value(DdTraceId).(string)
 	if ok {
-		req.Header[string(DdTraceId)] = append(req.Header[string(DdTraceId)], traceId)
+		req.Header.Set(string(DdTraceId), traceId)
 		if parentId, ok := ctx.Value(DdParentId).(string); ok {
-			req.Header[string(DdParentId)] = append(req.Header[string(DdParentId)], parentId)
+			req.Header.Set(string(DdParentId), parentId)
 		}
 		if spanId, ok := ctx.Value(DdSpanId).(string); ok {
-			req.Header[string(DdSpanId)] = append(req.Header[string(DdSpanId)], spanId)
+			req.Header.Set(string(DdSpanId), spanId)
 		}
 		if samplingPriority, ok := ctx.Value(DdSamplingPriority).(string); ok {
-			req.Header[string(DdSamplingPriority)] = append(req.Header[string(DdSamplingPriority)], samplingPriority)
+			req.Header.Set(string(DdSamplingPriority), samplingPriority)
 		}
 	} else {
-		req.Header[string(DdTraceId)] = append(req.Header[string(DdTraceId)], fmt.Sprint(functionExecutionSpan.Context().TraceID()))
-		req.Header[string(DdSpanId)] = append(req.Header[string(DdSpanId)], fmt.Sprint(functionExecutionSpan.Context().SpanID()))
+		req.Header.Set(string(DdTraceId), fmt.Sprint(functionExecutionSpan.Context().TraceID()))
+		req.Header.Set(string(DdSpanId), fmt.Sprint(functionExecutionSpan.Context().SpanID()))
 	}
 
 	response, err := em.httpClient.Do(req)

--- a/internal/extension/extension_test.go
+++ b/internal/extension/extension_test.go
@@ -72,12 +72,13 @@ func captureLog(f func()) string {
 }
 
 func TestBuildExtensionManager(t *testing.T) {
-	em := BuildExtensionManager()
+	em := BuildExtensionManager(false)
 	assert.Equal(t, "http://localhost:8124/lambda/hello", em.helloRoute)
 	assert.Equal(t, "http://localhost:8124/lambda/flush", em.flushRoute)
 	assert.Equal(t, "http://localhost:8124/lambda/start-invocation", em.startInvocationUrl)
 	assert.Equal(t, "http://localhost:8124/lambda/end-invocation", em.endInvocationUrl)
 	assert.Equal(t, "/opt/extensions/datadog-agent", em.extensionPath)
+	assert.Equal(t, false, em.isUniversalInstrumentation)
 	assert.NotNil(t, em.httpClient)
 }
 

--- a/internal/extension/extension_test.go
+++ b/internal/extension/extension_test.go
@@ -9,6 +9,7 @@
 package extension
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -26,6 +27,18 @@ type ClientSuccessMock struct {
 type ClientSuccess202Mock struct {
 }
 
+type ClientSuccessStartInvoke struct {
+}
+
+type ClientSuccessEndInvoke struct {
+}
+
+const (
+	mockTraceId          = "1"
+	mockParentId         = "2"
+	mockSamplingPriority = "3"
+)
+
 func (c *ClientErrorMock) Do(req *http.Request) (*http.Response, error) {
 	return nil, fmt.Errorf("KO")
 }
@@ -38,10 +51,25 @@ func (c *ClientSuccess202Mock) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{StatusCode: 202, Status: "KO"}, nil
 }
 
+func (c *ClientSuccessStartInvoke) Do(req *http.Request) (*http.Response, error) {
+	header := http.Header{}
+	header.Set(string(DdTraceId), mockTraceId)
+	header.Set(string(DdParentId), mockParentId)
+	header.Set(string(DdSamplingPriority), mockSamplingPriority)
+	return &http.Response{StatusCode: 200, Status: "KO", Header: header}, nil
+}
+
+func (c *ClientSuccessEndInvoke) Do(req *http.Request) (*http.Response, error) {
+	header := map[string][]string{}
+	return &http.Response{StatusCode: 200, Status: "KO", Header: header}, nil
+}
+
 func TestBuildExtensionManager(t *testing.T) {
 	em := BuildExtensionManager()
 	assert.Equal(t, "http://localhost:8124/lambda/hello", em.helloRoute)
 	assert.Equal(t, "http://localhost:8124/lambda/flush", em.flushRoute)
+	assert.Equal(t, "http://localhost:8124/lambda/start-invocation", em.startInvocationUrl)
+	assert.Equal(t, "http://localhost:8124/lambda/end-invocation", em.endInvocationUrl)
 	assert.Equal(t, "/opt/extensions/datadog-agent", em.extensionPath)
 	assert.NotNil(t, em.httpClient)
 }
@@ -95,4 +123,23 @@ func TestFlushSuccess(t *testing.T) {
 	}
 	err := em.Flush()
 	assert.Nil(t, err)
+}
+
+func TestExtensionStartInvokeWithTraceContext(t *testing.T) {
+	em := &ExtensionManager{
+		startInvocationUrl: startInvocationUrl,
+		httpClient:         &ClientSuccessStartInvoke{},
+	}
+	ctx := em.SendStartInvocationRequest(context.TODO(), []byte{})
+
+	// Ensure that we pull the DD trace context if this is a distributed trace
+	traceId := ctx.Value(DdTraceId)
+	parentId := ctx.Value(DdParentId)
+	samplingPriority := ctx.Value(DdSamplingPriority)
+	err := em.Flush()
+
+	assert.Nil(t, err)
+	assert.Equal(t, mockTraceId, traceId)
+	assert.Equal(t, mockParentId, parentId)
+	assert.Equal(t, mockSamplingPriority, samplingPriority)
 }

--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -72,10 +72,14 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 		tracerInitialized = true
 	}
 
-	functionExecutionSpan = startFunctionExecutionSpan(ctx, l.mergeXrayTraces)
+	functionExecutionSpan = startFunctionExecutionSpan(ctx, l.mergeXrayTraces, l.extensionManager.IsExtensionRunning())
 
 	// Add the span to the context so the user can create child spans
 	ctx = tracer.ContextWithSpan(ctx, functionExecutionSpan)
+
+	if l.extensionManager.IsExtensionRunning() {
+		ctx = l.extensionManager.SendStartInvocationRequest(ctx, msg)
+	}
 
 	return ctx
 }
@@ -84,13 +88,18 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 func (l *Listener) HandlerFinished(ctx context.Context, err error) {
 	if functionExecutionSpan != nil {
 		functionExecutionSpan.Finish(tracer.WithError(err))
+
+		if l.extensionManager.IsExtensionRunning() {
+			l.extensionManager.SendEndInvocationRequest(ctx, functionExecutionSpan, err)
+		}
 	}
+
 	tracer.Flush()
 }
 
 // startFunctionExecutionSpan starts a span that represents the current Lambda function execution
 // and returns the span so that it can be finished when the function execution is complete
-func startFunctionExecutionSpan(ctx context.Context, mergeXrayTraces bool) tracer.Span {
+func startFunctionExecutionSpan(ctx context.Context, mergeXrayTraces bool, isExtensionRunning bool) tracer.Span {
 	// Extract information from context
 	lambdaCtx, _ := lambdacontext.FromContext(ctx)
 	rootTraceContext, ok := ctx.Value(traceContextKey).(TraceContext)
@@ -109,11 +118,17 @@ func startFunctionExecutionSpan(ctx context.Context, mergeXrayTraces bool) trace
 		parentSpanContext = convertedSpanContext
 	}
 
+	resourceName := lambdacontext.FunctionName
+	if isExtensionRunning {
+		// The extension will drop this span, prioritizing the execution span the extension creates
+		resourceName = string(extension.DdSeverlessSpan)
+	}
+
 	span := tracer.StartSpan(
 		"aws.lambda", // This operation name will be replaced with the value of the service tag by the Forwarder
 		tracer.SpanType("serverless"),
 		tracer.ChildOf(parentSpanContext),
-		tracer.ResourceName(lambdacontext.FunctionName),
+		tracer.ResourceName(resourceName),
 		tracer.Tag("cold_start", ctx.Value("cold_start")),
 		tracer.Tag("function_arn", functionArn),
 		tracer.Tag("function_version", functionVersion),

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -74,7 +74,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, true)
+	span := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -104,7 +104,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, false)
+	span := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -123,7 +123,7 @@ func TestStartFunctionExecutionSpanFromEventWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, true)
+	span := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -142,7 +142,7 @@ func TestStartFunctionExecutionSpanFromEventWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, false)
+	span := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 

--- a/internal/wrapper/wrap_handler.go
+++ b/internal/wrapper/wrap_handler.go
@@ -60,6 +60,7 @@ func WrapHandlerWithListeners(handler interface{}, listeners ...HandlerListener)
 		CurrentContext = ctx
 		result, err := callHandler(ctx, msg, handler)
 		for _, listener := range listeners {
+			ctx = context.WithValue(ctx, extension.DdLambdaResponse, result)
 			listener.HandlerFinished(ctx, err)
 		}
 		coldStart = false
@@ -84,7 +85,6 @@ func (h *DatadogHandler) Invoke(ctx context.Context, payload []byte) ([]byte, er
 	CurrentContext = ctx
 	result, err := h.handler.Invoke(ctx, payload)
 	for _, listener := range h.listeners {
-		ctx = context.WithValue(ctx, extension.DdLambdaResponse, result)
 		listener.HandlerFinished(ctx, err)
 	}
 	h.coldStart = false

--- a/internal/wrapper/wrap_handler.go
+++ b/internal/wrapper/wrap_handler.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/DataDog/datadog-lambda-go/internal/extension"
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 	"github.com/aws/aws-lambda-go/lambda"
 
@@ -83,6 +84,7 @@ func (h *DatadogHandler) Invoke(ctx context.Context, payload []byte) ([]byte, er
 	CurrentContext = ctx
 	result, err := h.handler.Invoke(ctx, payload)
 	for _, listener := range h.listeners {
+		ctx = context.WithValue(ctx, extension.DdLambdaResponse, result)
 		listener.HandlerFinished(ctx, err)
 	}
 	h.coldStart = false


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Extends the DD extension functionality in the Go Lambda library to support universal instrumentation. In short, this means that the extension will handle certain features such as adding function triggers, Lambda request and response to the span metadata and inferred spans.

Gated behind the `DD_UNIVERSAL_INSTRUMENTATION` env var.

![Image 2022-10-06 at 11 23 45 AM](https://user-images.githubusercontent.com/25290232/194354779-6ec352d4-ae8c-434d-b12e-763e121c8f3a.jpg)

### Motivation

<!--- What inspired you to submit this pull request? --->
Expand universal instrumentation to all runtimes. 

### Testing Guidelines

<!--- How did you test this pull request? --->
Manually with dev builds of the library

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
