### PR TITLE
run integration tests locally on M1

### DIFF
--- a/tests/integration_tests/run_integration_tests.sh
+++ b/tests/integration_tests/run_integration_tests.sh
@@ -40,8 +40,8 @@ if [ -n "$UPDATE_SNAPSHOTS" ]; then
 fi
 
 echo "Building Go binaries"
-GOOS=linux go build -ldflags="-s -w" -o bin/hello hello/main.go
-GOOS=linux go build -ldflags="-s -w" -o bin/error error/main.go
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/hello hello/main.go
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/error error/main.go
 
 # Generate a random 8-character ID to avoid collisions with other runs
 run_id=$(xxd -l 4 -c 4 -p < /dev/random)


### PR DESCRIPTION
### What does this PR do?

Explicitly set the architecture to be able to run integration testing on M1