### PR TITLE
feat: Add option for Processor to drop metrics

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -71,6 +71,13 @@ type (
 		// TraceContextExtractor is the function that extracts a root/parent trace context from the Lambda event body.
 		// See trace.DefaultTraceExtractor for an example.
 		TraceContextExtractor trace.ContextExtractor
+		// MetricsChannelCapacity sets the capacity to buffer metrics if ShouldUseLogForwarder is set to false.
+		// default: 2000
+		MetricsChannelCapacity uint32
+		// DropMetricsAtCapacity controls if metrics should be dropped
+		// instead of blocking to wait for capacity on the metrics channel.
+		// default: false
+		DropMetricsAtCapacity bool
 	}
 )
 

--- a/internal/metrics/constants.go
+++ b/internal/metrics/constants.go
@@ -18,6 +18,7 @@ const (
 	defaultCircuitBreakerInterval      = time.Second * 30
 	defaultCircuitBreakerTimeout       = time.Second * 60
 	defaultCircuitBreakerTotalFailures = 4
+	defaultMetricsChannelCapacity      = 2000
 )
 
 // MetricType enumerates all the available metric types

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -49,6 +49,8 @@ type (
 		CircuitBreakerInterval      time.Duration
 		CircuitBreakerTimeout       time.Duration
 		CircuitBreakerTotalFailures uint32
+		MetricsChannelCapacity      uint32
+		DropMetricsAtCapacity       bool
 	}
 
 	logMetric struct {
@@ -84,6 +86,9 @@ func MakeListener(config Config, extensionManager *extension.ExtensionManager) L
 	if config.BatchInterval <= 0 {
 		config.BatchInterval = defaultBatchInterval
 	}
+	if config.MetricsChannelCapacity == 0 {
+		config.MetricsChannelCapacity = defaultMetricsChannelCapacity
+	}
 
 	var statsdClient *statsd.Client
 	// immediate call to the Agent, if not a 200, fallback to API
@@ -118,7 +123,7 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 	}
 
 	ts := MakeTimeService()
-	pr := MakeProcessor(ctx, l.apiClient, ts, l.config.BatchInterval, l.config.ShouldRetryOnFailure, l.config.CircuitBreakerInterval, l.config.CircuitBreakerTimeout, l.config.CircuitBreakerTotalFailures)
+	pr := MakeProcessor(ctx, l.apiClient, ts, l.config.BatchInterval, l.config.ShouldRetryOnFailure, l.config.CircuitBreakerInterval, l.config.CircuitBreakerTimeout, l.config.CircuitBreakerTotalFailures, l.config.MetricsChannelCapacity, l.config.DropMetricsAtCapacity)
 	l.processor = pr
 
 	ctx = AddListener(ctx, l)

--- a/internal/metrics/processor.go
+++ b/internal/metrics/processor.go
@@ -10,6 +10,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -18,6 +19,9 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/sony/gobreaker"
 )
+
+// ErrMetricsChannelAtCapacity reports that the processors metricsChan is at capacity and unable receive more metrics.
+var ErrMetricsChannelAtCapacity = errors.New("channel is at capacity, metrics will be dropped")
 
 type (
 	// Processor is used to batch metrics on a background thread, and send them on to a client periodically.
@@ -33,36 +37,39 @@ type (
 	}
 
 	processor struct {
-		context           context.Context
-		metricsChan       chan Metric
-		timeService       TimeService
-		waitGroup         sync.WaitGroup
-		batchInterval     time.Duration
-		client            Client
-		batcher           *Batcher
-		shouldRetryOnFail bool
-		isProcessing      bool
-		breaker           *gobreaker.CircuitBreaker
+		context               context.Context
+		metricsChan           chan Metric
+		metricsChanCapacity   int
+		dropMetricsAtCapacity bool
+		timeService           TimeService
+		waitGroup             sync.WaitGroup
+		batchInterval         time.Duration
+		client                Client
+		batcher               *Batcher
+		shouldRetryOnFail     bool
+		isProcessing          bool
+		breaker               *gobreaker.CircuitBreaker
 	}
 )
 
 // MakeProcessor creates a new metrics context
-func MakeProcessor(ctx context.Context, client Client, timeService TimeService, batchInterval time.Duration, shouldRetryOnFail bool, circuitBreakerInterval time.Duration, circuitBreakerTimeout time.Duration, circuitBreakerTotalFailures uint32) Processor {
+func MakeProcessor(ctx context.Context, client Client, timeService TimeService, batchInterval time.Duration, shouldRetryOnFail bool, circuitBreakerInterval time.Duration, circuitBreakerTimeout time.Duration, circuitBreakerTotalFailures uint32, metricsChanCapacity uint32, dropMetricsAtCapacity bool) Processor {
 	batcher := MakeBatcher(batchInterval)
 
 	breaker := MakeCircuitBreaker(circuitBreakerInterval, circuitBreakerTimeout, circuitBreakerTotalFailures)
 
 	return &processor{
-		context:           ctx,
-		metricsChan:       make(chan Metric, 2000),
-		batchInterval:     batchInterval,
-		waitGroup:         sync.WaitGroup{},
-		client:            client,
-		batcher:           batcher,
-		shouldRetryOnFail: shouldRetryOnFail,
-		timeService:       timeService,
-		isProcessing:      false,
-		breaker:           breaker,
+		context:               ctx,
+		metricsChan:           make(chan Metric, metricsChanCapacity),
+		dropMetricsAtCapacity: dropMetricsAtCapacity,
+		batchInterval:         batchInterval,
+		waitGroup:             sync.WaitGroup{},
+		client:                client,
+		batcher:               batcher,
+		shouldRetryOnFail:     shouldRetryOnFail,
+		timeService:           timeService,
+		isProcessing:          false,
+		breaker:               breaker,
 	}
 }
 
@@ -83,7 +90,16 @@ func MakeCircuitBreaker(circuitBreakerInterval time.Duration, circuitBreakerTime
 func (p *processor) AddMetric(metric Metric) {
 	// We use a large buffer in the metrics channel, to make this operation non-blocking.
 	// However, if the channel does fill up, this will become a blocking operation.
-	p.metricsChan <- metric
+	// Set DropMetricsAtCapacity to true in order to drop the metric instead of blocking.
+	if p.dropMetricsAtCapacity {
+		select {
+		case p.metricsChan <- metric:
+		default:
+			logger.Error(ErrMetricsChannelAtCapacity)
+		}
+	} else {
+		p.metricsChan <- metric
+	}
 }
 
 func (p *processor) StartProcessing() {


### PR DESCRIPTION
### What does this PR do?

Add two parameters `MetricsChannelCapacity` and `DropMetricsAtCapacity`.

This will allow the `AddMetric` function to be truly non-blocking even if we risk loosing some metrics.

The default will remain at a channel capacity of 2000 and blocking to wait for capacity.

### Motivation

Following the DataDog outage of 2023.03.08 in EU central some of our Lambdas were blocking due to the blocking nature of the `AddMetric` function in cases where the `metricsChan` is at capacity.

### Testing Guidelines

Added test case `TestProcessorBatchesDropMetricsAtCapacity`

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
