### PR TITLE
Propagate trace context from SQS events

### DIFF
--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -109,7 +109,10 @@ func (em *ExtensionManager) SendStartInvocationRequest(ctx context.Context, even
 		if traceId != "" {
 			ctx = context.WithValue(ctx, DdTraceId, traceId)
 		}
-		parentId := response.Header.Get(string(DdParentId))
+		parentId := traceId
+		if pid := response.Header.Get(string(DdParentId)); pid != "" {
+			parentId = pid
+		}
 		if parentId != "" {
 			ctx = context.WithValue(ctx, DdParentId, parentId)
 		}

--- a/internal/extension/extension_test.go
+++ b/internal/extension/extension_test.go
@@ -174,6 +174,29 @@ func TestExtensionStartInvokeWithTraceContext(t *testing.T) {
 	assert.Equal(t, mockSamplingPriority, samplingPriority)
 }
 
+func TestExtensionStartInvokeWithTraceContextNoParentID(t *testing.T) {
+	headers := http.Header{}
+	headers.Set(string(DdTraceId), mockTraceId)
+	headers.Set(string(DdSamplingPriority), mockSamplingPriority)
+
+	em := &ExtensionManager{
+		startInvocationUrl: startInvocationUrl,
+		httpClient: &ClientSuccessStartInvoke{
+			headers: headers,
+		},
+	}
+	ctx := em.SendStartInvocationRequest(context.TODO(), []byte{})
+	traceId := ctx.Value(DdTraceId)
+	parentId := ctx.Value(DdParentId)
+	samplingPriority := ctx.Value(DdSamplingPriority)
+	err := em.Flush()
+
+	assert.Nil(t, err)
+	assert.Equal(t, mockTraceId, traceId)
+	assert.Equal(t, mockTraceId, parentId)
+	assert.Equal(t, mockSamplingPriority, samplingPriority)
+}
+
 func TestExtensionEndInvocation(t *testing.T) {
 	em := &ExtensionManager{
 		endInvocationUrl: endInvocationUrl,

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -156,7 +156,7 @@ func getTraceContext(ctx context.Context, headers map[string]string) (TraceConte
 			samplingPriority = val
 		}
 	}
-	if samplingPriority == "" || samplingPriority == "-128" {
+	if samplingPriority == "" {
 		samplingPriority = "1" //sampler-keep
 	}
 

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/DataDog/datadog-lambda-go/internal/extension"
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/header"
 	"github.com/aws/aws-xray-sdk-go/xray"
@@ -47,7 +48,7 @@ var DefaultTraceExtractor = getHeadersFromEventHeaders
 // contextWithRootTraceContext uses the incoming event and context object payloads to determine
 // the root TraceContext and then adds that TraceContext to the context object.
 func contextWithRootTraceContext(ctx context.Context, ev json.RawMessage, mergeXrayTraces bool, extractor ContextExtractor) (context.Context, error) {
-	datadogTraceContext, gotDatadogTraceContext := getTraceContext(extractor(ctx, ev))
+	datadogTraceContext, gotDatadogTraceContext := getTraceContext(ctx, extractor(ctx, ev))
 
 	xrayTraceContext, errGettingXrayContext := convertXrayTraceContextFromLambdaContext(ctx)
 	if errGettingXrayContext != nil {
@@ -126,21 +127,36 @@ func createDummySubsegmentForXrayConverter(ctx context.Context, traceCtx TraceCo
 	return nil
 }
 
-func getTraceContext(context map[string]string) (TraceContext, bool) {
+func getTraceContext(ctx context.Context, headers map[string]string) (TraceContext, bool) {
 	tc := TraceContext{}
 
-	traceID, ok := context[traceIDHeader]
-	if !ok {
+	traceID := headers[traceIDHeader]
+	if traceID == "" {
+		if val, ok := ctx.Value(extension.DdTraceId).(string); ok {
+			traceID = val
+		}
+	}
+	if traceID == "" {
 		return tc, false
 	}
 
-	parentID, ok := context[parentIDHeader]
-	if !ok {
+	parentID := headers[parentIDHeader]
+	if parentID == "" {
+		if val, ok := ctx.Value(extension.DdParentId).(string); ok {
+			parentID = val
+		}
+	}
+	if parentID == "" {
 		return tc, false
 	}
 
-	samplingPriority, ok := context[samplingPriorityHeader]
-	if !ok {
+	samplingPriority := headers[samplingPriorityHeader]
+	if samplingPriority == "" {
+		if val, ok := ctx.Value(extension.DdSamplingPriority).(string); ok {
+			samplingPriority = val
+		}
+	}
+	if samplingPriority == "" || samplingPriority == "-128" {
 		samplingPriority = "1" //sampler-keep
 	}
 

--- a/internal/trace/context_test.go
+++ b/internal/trace/context_test.go
@@ -60,7 +60,7 @@ func TestGetDatadogTraceContextForTraceMetadataNonProxyEvent(t *testing.T) {
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/apig-event-with-headers.json")
 
-	headers, ok := getTraceContext(getHeadersFromEventHeaders(ctx, *ev))
+	headers, ok := getTraceContext(ctx, getHeadersFromEventHeaders(ctx, *ev))
 	assert.True(t, ok)
 
 	expected := TraceContext{
@@ -75,7 +75,7 @@ func TestGetDatadogTraceContextForTraceMetadataWithMixedCaseHeaders(t *testing.T
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/non-proxy-with-mixed-case-headers.json")
 
-	headers, ok := getTraceContext(getHeadersFromEventHeaders(ctx, *ev))
+	headers, ok := getTraceContext(ctx, getHeadersFromEventHeaders(ctx, *ev))
 	assert.True(t, ok)
 
 	expected := TraceContext{
@@ -90,7 +90,7 @@ func TestGetDatadogTraceContextForTraceMetadataWithMissingSamplingPriority(t *te
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/non-proxy-with-missing-sampling-priority.json")
 
-	headers, ok := getTraceContext(getHeadersFromEventHeaders(ctx, *ev))
+	headers, ok := getTraceContext(ctx, getHeadersFromEventHeaders(ctx, *ev))
 	assert.True(t, ok)
 
 	expected := TraceContext{
@@ -105,7 +105,7 @@ func TestGetDatadogTraceContextForInvalidData(t *testing.T) {
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/invalid.json")
 
-	_, ok := getTraceContext(getHeadersFromEventHeaders(ctx, *ev))
+	_, ok := getTraceContext(ctx, getHeadersFromEventHeaders(ctx, *ev))
 	assert.False(t, ok)
 }
 
@@ -113,7 +113,7 @@ func TestGetDatadogTraceContextForMissingData(t *testing.T) {
 	ctx := mockLambdaXRayTraceContext(context.Background(), mockXRayTraceID, mockXRayEntityID, true)
 	ev := loadRawJSON(t, "../testdata/non-proxy-no-headers.json")
 
-	_, ok := getTraceContext(getHeadersFromEventHeaders(ctx, *ev))
+	_, ok := getTraceContext(ctx, getHeadersFromEventHeaders(ctx, *ev))
 	assert.False(t, ok)
 }
 

--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -64,6 +64,10 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 		return ctx
 	}
 
+	if l.universalInstrumentation && l.extensionManager.IsExtensionRunning() {
+		ctx = l.extensionManager.SendStartInvocationRequest(ctx, msg)
+	}
+
 	ctx, _ = contextWithRootTraceContext(ctx, msg, l.mergeXrayTraces, l.traceContextExtractor)
 
 	if !tracerInitialized {
@@ -81,10 +85,6 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 
 	// Add the span to the context so the user can create child spans
 	ctx = tracer.ContextWithSpan(ctx, functionExecutionSpan)
-
-	if l.universalInstrumentation && l.extensionManager.IsExtensionRunning() {
-		ctx = l.extensionManager.SendStartInvocationRequest(ctx, msg)
-	}
 
 	return ctx
 }

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -75,7 +75,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, true, false)
+	span, _ := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -105,7 +105,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, false, false)
+	span, _ := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -124,7 +124,7 @@ func TestStartFunctionExecutionSpanFromEventWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, true, false)
+	span, _ := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -143,7 +143,7 @@ func TestStartFunctionExecutionSpanFromEventWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, false, false)
+	span, _ := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -162,7 +162,7 @@ func TestStartFunctionExecutionSpanWithExtension(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span := startFunctionExecutionSpan(ctx, false, true)
+	span, _ := startFunctionExecutionSpan(ctx, false, true)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 

--- a/internal/trace/listener_test.go
+++ b/internal/trace/listener_test.go
@@ -10,6 +10,7 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/DataDog/datadog-lambda-go/internal/extension"
@@ -75,7 +76,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span, _ := startFunctionExecutionSpan(ctx, true, false)
+	span, ctx := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
@@ -91,6 +92,7 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeEnabled(t *testing.T) {
 	assert.Equal(t, "mockfunctionname", finishedSpan.Tag("functionname"))
 	assert.Equal(t, "serverless", finishedSpan.Tag("span.type"))
 	assert.Equal(t, "xray", finishedSpan.Tag("_dd.parent_source"))
+	assert.Equal(t, fmt.Sprint(span.Context().SpanID()), ctx.Value(extension.DdSpanId).(string))
 }
 
 func TestStartFunctionExecutionSpanFromXrayWithMergeDisabled(t *testing.T) {
@@ -105,11 +107,12 @@ func TestStartFunctionExecutionSpanFromXrayWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span, _ := startFunctionExecutionSpan(ctx, false, false)
+	span, ctx := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
 	assert.Equal(t, nil, finishedSpan.Tag("_dd.parent_source"))
+	assert.Equal(t, fmt.Sprint(span.Context().SpanID()), ctx.Value(extension.DdSpanId).(string))
 }
 
 func TestStartFunctionExecutionSpanFromEventWithMergeEnabled(t *testing.T) {
@@ -124,11 +127,12 @@ func TestStartFunctionExecutionSpanFromEventWithMergeEnabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span, _ := startFunctionExecutionSpan(ctx, true, false)
+	span, ctx := startFunctionExecutionSpan(ctx, true, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
 	assert.Equal(t, "xray", finishedSpan.Tag("_dd.parent_source"))
+	assert.Equal(t, fmt.Sprint(span.Context().SpanID()), ctx.Value(extension.DdSpanId).(string))
 }
 
 func TestStartFunctionExecutionSpanFromEventWithMergeDisabled(t *testing.T) {
@@ -143,11 +147,12 @@ func TestStartFunctionExecutionSpanFromEventWithMergeDisabled(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span, _ := startFunctionExecutionSpan(ctx, false, false)
+	span, ctx := startFunctionExecutionSpan(ctx, false, false)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
 	assert.Equal(t, nil, finishedSpan.Tag("_dd.parent_source"))
+	assert.Equal(t, fmt.Sprint(span.Context().SpanID()), ctx.Value(extension.DdSpanId).(string))
 }
 
 func TestStartFunctionExecutionSpanWithExtension(t *testing.T) {
@@ -162,9 +167,10 @@ func TestStartFunctionExecutionSpanWithExtension(t *testing.T) {
 	mt := mocktracer.Start()
 	defer mt.Stop()
 
-	span, _ := startFunctionExecutionSpan(ctx, false, true)
+	span, ctx := startFunctionExecutionSpan(ctx, false, true)
 	span.Finish()
 	finishedSpan := mt.FinishedSpans()[0]
 
 	assert.Equal(t, string(extension.DdSeverlessSpan), finishedSpan.Tag("resource.name"))
+	assert.Equal(t, fmt.Sprint(span.Context().SpanID()), ctx.Value(extension.DdSpanId).(string))
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
When this lambda function is a consumer for a SQS queue, collect the trace context passed back from the extension and apply it.

### Motivation

<!--- What inspired you to submit this pull request? --->
Traces with a go SQS consumer were broken.

### Testing Guidelines

<!--- How did you test this pull request? --->
Sample trace using these updates

<img width="1056" alt="Screenshot 2023-09-12 at 12 21 13 PM" src="https://github.com/DataDog/datadog-lambda-go/assets/1383216/9000ca54-993e-40aa-b4ae-23f6f0f9cf50">

Note that any child span created inside the lambda function currently will not appear in the trace. This is because the extension isn't reading sampling priority and therefore the tracer defaults to priority 0 (throw it away). See https://datadoghq.atlassian.net/browse/SVLS-3537.

### Additional Notes

<!--- Anything else we should know when reviewing? --->
For some reason I am not seeing the `aws.lambda` span created for my sqs consumer. This should be created in the extension when universal instrumentation is turned on. I haven't been able to get to the bottom of this. However, I have been able to show that any child spans created in the SQS comsumer lambda will have the proper trace ID and show up properly in the trace.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
