### PR TITLE
feat: automate AppSec enablement setup (e.g: `AWS_LAMBDA_RUNTIME_API`)

### DIFF
--- a/awslambdanorpc.go
+++ b/awslambdanorpc.go
@@ -1,0 +1,14 @@
+//go:build lambda.norpc
+// +build lambda.norpc
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package ddlambda
+
+const awsLambdaRpcSupport = false

--- a/awslambdawithrpc.go
+++ b/awslambdawithrpc.go
@@ -1,0 +1,14 @@
+//go:build !lambda.norpc
+// +build !lambda.norpc
+
+/*
+* Unless explicitly stated otherwise all files in this repository are licensed
+* under the Apache License Version 2.0.
+*
+* This product includes software developed at Datadog (https://www.datadoghq.com/).
+* Copyright 2021 Datadog, Inc.
+ */
+
+package ddlambda
+
+const awsLambdaRpcSupport = true

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/path"
-
 	"github.com/DataDog/datadog-lambda-go/internal/extension"
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 	"github.com/DataDog/datadog-lambda-go/internal/metrics"
@@ -320,7 +318,7 @@ func setupAppSec() {
 		return
 	}
 
-	if present, err := path.Exists(path.CheckFollowSymlink, ddExtensionFilePath); err != nil || !present {
+	if _, err := os.Stat(ddExtensionFilePath); os.IsNotExist(err) {
 		logger.Debug(fmt.Sprintf("%s is enabled, but the Datadog extension was not found at %s", serverlessAppSecEnabledEnvVar, ddExtensionFilePath))
 		return
 	}
@@ -333,9 +331,9 @@ func setupAppSec() {
 
 	if val := os.Getenv(UniversalInstrumentation); val == "" {
 		if err := os.Setenv(UniversalInstrumentation, "1"); err != nil {
-			logger.Debug(fmt.Sprintf("failed to set %s=%s: %v", UniversalInstrumentation, 1, err))
+			logger.Debug(fmt.Sprintf("failed to set %s=%d: %v", UniversalInstrumentation, 1, err))
 		} else {
-			logger.Debug(fmt.Sprintf("successfully set %s=%s", UniversalInstrumentation, 1))
+			logger.Debug(fmt.Sprintf("successfully set %s=%d", UniversalInstrumentation, 1))
 		}
 	}
 }

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -297,12 +297,12 @@ func (cfg *Config) toMetricsConfig(isExtensionRunning bool) metrics.Config {
 // on universal instrumentation unless it was already configured by the customer, so
 // that the HTTP constext (invocation details span tags) is avaialble on AppSec traces.
 func setupAppSec() {
-	const ServerlessAppSSecEnabledEnvVar = "DD_SERVERLESS_APPSEC_ENABLED"
+	const ServerlessAppSecEnabledEnvVar = "DD_SERVERLESS_APPSEC_ENABLED"
 	const AwsLambdaRuntimeApiEnvVar = "AWS_LAMBDA_RUNTIME_API"
 	const DatadogAgentUrl = "127.0.0.1:9000"
 
 	enabled := false
-	if env := os.Getenv(ServerlessAppSSecEnabledEnvVar); env != "" {
+	if env := os.Getenv(ServerlessAppSecEnabledEnvVar); env != "" {
 		if on, err := strconv.ParseBool(env); err == nil {
 			enabled = on
 		}

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -14,12 +14,12 @@ type LogLevel int
 const (
 	// LevelDebug logs all information
 	LevelDebug LogLevel = iota
-	// LevelError only logs errors
-	LevelError LogLevel = iota
+	// LevelWarn only logs warnings and errors
+	LevelWarn LogLevel = iota
 )
 
 var (
-	logLevel           = LevelError
+	logLevel           = LevelWarn
 	output   io.Writer = os.Stdout
 )
 
@@ -36,12 +36,6 @@ func SetOutput(w io.Writer) {
 
 // Error logs a structured error message to stdout
 func Error(err error) {
-
-	type logStructure struct {
-		Status  string `json:"status"`
-		Message string `json:"message"`
-	}
-
 	finalMessage := logStructure{
 		Status:  "error",
 		Message: fmt.Sprintf("datadog: %s", err.Error()),
@@ -56,12 +50,23 @@ func Debug(message string) {
 	if logLevel > LevelDebug {
 		return
 	}
-	type logStructure struct {
-		Status  string `json:"status"`
-		Message string `json:"message"`
-	}
 	finalMessage := logStructure{
 		Status:  "debug",
+		Message: fmt.Sprintf("datadog: %s", message),
+	}
+
+	result, _ := json.Marshal(finalMessage)
+
+	log.Println(string(result))
+}
+
+// Warn logs a structured log message to stdout
+func Warn(message string) {
+	if logLevel > LevelWarn {
+		return
+	}
+	finalMessage := logStructure{
+		Status:  "warning",
 		Message: fmt.Sprintf("datadog: %s", message),
 	}
 
@@ -73,4 +78,9 @@ func Debug(message string) {
 // Raw prints a raw message to the logs.
 func Raw(message string) {
 	fmt.Fprintln(output, message)
+}
+
+type logStructure struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }


### PR DESCRIPTION
### What does this PR do?

In order to simplify onboarding & make it more uniform across languages, inspect the value of the `DD_SERVERLESS_APPSEC_ENABLED` environment variable, and overrides `AWS_LAMBDA_RUNTIME_API` to redirect the Lambda runtime API to the Datadog extension so that the AppSec proxy is used, and turns on `DD_UNIVERSAL_INSTRUMENTATION` (unless it was already manually configured by the user).

### Motivation

This is necessary/useful because the `AWS_LAMBDA_EXEC_WRAPPER` environment variable is not honored by custom runtimes (`provided`, `provided.al2`) as well as the `go1.x` runtime (which is a glorified provided runtime). The datadog Lambda wrapper starts a proxy to inject ASM functionality directly on the Lambda runtime API instead of having to manually instrument each and every lambda handler/application, and modifies `AWS_LAMBDA_RUNTIME_API` to instruct Lambda language runtime client libraries to go through it instead of directly interacting with the Lambda control plane.

### Testing Guidelines

Deployed it on AWS Lambda with a demo app of mine and observed the expected behavior.

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
