### PR TITLE
feat: enable universal instrumentation by default

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -202,9 +202,9 @@ func InvokeDryRun(callback func(ctx context.Context), cfg *Config) (interface{},
 
 func (cfg *Config) toTraceConfig() trace.Config {
 	traceConfig := trace.Config{
-		DDTraceEnabled:           false,
+		DDTraceEnabled:           true,
 		MergeXrayTraces:          false,
-		UniversalInstrumentation: false,
+		UniversalInstrumentation: true,
 	}
 
 	if cfg != nil {
@@ -217,16 +217,16 @@ func (cfg *Config) toTraceConfig() trace.Config {
 		traceConfig.TraceContextExtractor = trace.DefaultTraceExtractor
 	}
 
-	if !traceConfig.DDTraceEnabled {
-		traceConfig.DDTraceEnabled, _ = strconv.ParseBool(os.Getenv(DatadogTraceEnabledEnvVar))
+	if tracingEnabled, err := strconv.ParseBool(os.Getenv(DatadogTraceEnabledEnvVar)); err == nil {
+		traceConfig.DDTraceEnabled = tracingEnabled;
 	}
 
 	if !traceConfig.MergeXrayTraces {
 		traceConfig.MergeXrayTraces, _ = strconv.ParseBool(os.Getenv(MergeXrayTracesEnvVar))
 	}
 
-	if !traceConfig.UniversalInstrumentation {
-		traceConfig.UniversalInstrumentation, _ = strconv.ParseBool(os.Getenv(UniversalInstrumentation))
+	if universalInstrumentation, err := strconv.ParseBool(os.Getenv(UniversalInstrumentation)); err == nil {
+		traceConfig.UniversalInstrumentation = universalInstrumentation
 	}
 
 	return traceConfig

--- a/ddlambda_test.go
+++ b/ddlambda_test.go
@@ -11,12 +11,16 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInvokeDryRun(t *testing.T) {
+	os.Setenv(UniversalInstrumentation, "false")
+	os.Setenv(DatadogTraceEnabledEnvVar, "false")
+
 	called := false
 	_, err := InvokeDryRun(func(ctx context.Context) {
 		called = true
@@ -25,6 +29,9 @@ func TestInvokeDryRun(t *testing.T) {
 	}, nil)
 	assert.NoError(t, err)
 	assert.True(t, called)
+
+	os.Unsetenv(UniversalInstrumentation)
+	os.Unsetenv(DatadogTraceEnabledEnvVar)
 }
 
 func TestMetricsSilentFailWithoutWrapper(t *testing.T) {

--- a/ddlambda_test.go
+++ b/ddlambda_test.go
@@ -11,15 +11,14 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInvokeDryRun(t *testing.T) {
-	os.Setenv(UniversalInstrumentation, "false")
-	os.Setenv(DatadogTraceEnabledEnvVar, "false")
+	t.Setenv(UniversalInstrumentation, "false")
+	t.Setenv(DatadogTraceEnabledEnvVar, "false")
 
 	called := false
 	_, err := InvokeDryRun(func(ctx context.Context) {
@@ -29,9 +28,6 @@ func TestInvokeDryRun(t *testing.T) {
 	}, nil)
 	assert.NoError(t, err)
 	assert.True(t, called)
-
-	os.Unsetenv(UniversalInstrumentation)
-	os.Unsetenv(DatadogTraceEnabledEnvVar)
 }
 
 func TestMetricsSilentFailWithoutWrapper(t *testing.T) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->


### What does this PR do?

Enabled universal instrumentation and tracing by default.

Honors environment variable if set.

![Screenshot 2023-12-07 at 4 33 14 PM](https://github.com/DataDog/datadog-lambda-go/assets/30836115/0e0e4cfa-0c5a-4bf2-b4f7-7d7a979d449c)

### Motivation

Multiple tickets of customers not understanding why they need to have another env var to get inferred spans ready.

### Testing Guidelines

- Updated unit tests to respect previous behavior: tracing and universal instrumentation disabled.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
