### PR TITLE
Do not call flush extension after each invocation.

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -304,6 +304,10 @@ func (cfg *Config) toMetricsConfig(isExtensionRunning bool) metrics.Config {
 		mc.EnhancedMetrics = strings.EqualFold(enhancedMetrics, "true")
 	}
 
+	if localTest := os.Getenv("DD_LOCAL_TEST"); localTest == "true" || localTest == "1" {
+		mc.LocalTest = true
+	}
+
 	return mc
 }
 

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -304,7 +304,7 @@ func (cfg *Config) toMetricsConfig(isExtensionRunning bool) metrics.Config {
 		mc.EnhancedMetrics = strings.EqualFold(enhancedMetrics, "true")
 	}
 
-	if localTest := os.Getenv("DD_LOCAL_TEST"); localTest == "true" || localTest == "1" {
+	if localTest := os.Getenv("DD_LOCAL_TEST"); localTest == "1" || strings.ToLower(localTest) == "true" {
 		mc.LocalTest = true
 	}
 

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -49,6 +49,7 @@ type (
 		CircuitBreakerInterval      time.Duration
 		CircuitBreakerTimeout       time.Duration
 		CircuitBreakerTotalFailures uint32
+		LocalTest                   bool
 	}
 
 	logMetric struct {
@@ -143,8 +144,10 @@ func (l *Listener) HandlerFinished(ctx context.Context, err error) {
 			}
 		}
 		// send a message to the Agent to flush the metrics
-		if err := l.extensionManager.Flush(); err != nil {
-			logger.Error(fmt.Errorf("error while flushing the metrics: %s", err))
+		if l.config.LocalTest {
+			if err := l.extensionManager.Flush(); err != nil {
+				logger.Error(fmt.Errorf("error while flushing the metrics: %s", err))
+			}
 		}
 	} else {
 		// use the api


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Only calls `Flush()` on the extension when running in local test mode.

See https://github.com/DataDog/datadog-lambda-python/pull/406

### Motivation

<!--- What inspired you to submit this pull request? --->

This cuts runtime duration of a hello world function by about 10%.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
