### PR TITLE
internal/trace/listener: Don't override service name

### DIFF
--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/DataDog/datadog-lambda-go/internal/extension"
@@ -71,7 +72,12 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 	ctx, _ = contextWithRootTraceContext(ctx, msg, l.mergeXrayTraces, l.traceContextExtractor)
 
 	if !tracerInitialized {
+		serviceName := os.Getenv("DD_SERVICE")
+		if serviceName == "" {
+			serviceName = "aws.lambda"
+		}
 		tracer.Start(
+			tracer.WithService(serviceName),
 			tracer.WithLambdaMode(!l.extensionManager.IsExtensionRunning()),
 			tracer.WithGlobalTag("_dd.origin", "lambda"),
 			tracer.WithSendRetries(2),

--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -72,7 +72,6 @@ func (l *Listener) HandlerStarted(ctx context.Context, msg json.RawMessage) cont
 
 	if !tracerInitialized {
 		tracer.Start(
-			tracer.WithService("aws.lambda"),
 			tracer.WithLambdaMode(!l.extensionManager.IsExtensionRunning()),
 			tracer.WithGlobalTag("_dd.origin", "lambda"),
 			tracer.WithSendRetries(2),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Today, if `DD_SERVICE` is used, the service name is still set to `aws.lambda`.
This PR removes that logic, and uses the defaults of the Go tracer (so defaulting to the binary name).

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Behavior before:

Traces have a service name `aws.lambda` is `DD_SERVICE` isn't set
Data streams have a service `aws.lambda` if `DD_SERVICE` isn't set

If DD_SERVICE is set, only APM picks it up.

Behavior after:

Same if DD_SERVICE isn't set

If DD_SERVICE is set, both APM service name & DSM service name use it.
<img width="528" alt="image" src="https://github.com/DataDog/datadog-lambda-go/assets/15872804/0e9735d1-d712-456b-b085-0664dfa51650">


<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
