### PR TITLE
Send error message along with error flag

### DIFF
--- a/internal/extension/extension.go
+++ b/internal/extension/extension.go
@@ -25,11 +25,12 @@ import (
 type ddTraceContext string
 
 const (
-	DdTraceId          ddTraceContext = "x-datadog-trace-id"
-	DdParentId         ddTraceContext = "x-datadog-parent-id"
-	DdSpanId           ddTraceContext = "x-datadog-span-id"
-	DdSamplingPriority ddTraceContext = "x-datadog-sampling-priority"
-	DdInvocationError  ddTraceContext = "x-datadog-invocation-error"
+	DdTraceId            ddTraceContext = "x-datadog-trace-id"
+	DdParentId           ddTraceContext = "x-datadog-parent-id"
+	DdSpanId             ddTraceContext = "x-datadog-span-id"
+	DdSamplingPriority   ddTraceContext = "x-datadog-sampling-priority"
+	DdInvocationError    ddTraceContext = "x-datadog-invocation-error"
+	DdInvocationErrorMsg ddTraceContext = "x-datadog-invocation-error-msg"
 
 	DdSeverlessSpan  ddTraceContext = "dd-tracer-serverless-span"
 	DdLambdaResponse ddTraceContext = "dd-response"
@@ -137,6 +138,7 @@ func (em *ExtensionManager) SendEndInvocationRequest(ctx context.Context, functi
 	// Mark the invocation as an error if any
 	if err != nil {
 		req.Header.Set(string(DdInvocationError), "true")
+		req.Header.Set(string(DdInvocationErrorMsg), err.Error())
 	}
 
 	// Extract the DD trace context and pass them to the extension via request headers


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This sends the error message along with an error flag 

### Motivation

When running with universal instrumentation on were loosing error messages if lambdas are returning errors, which impacts our ability to debug issues:
<img width="990" alt="image" src="https://github.com/DataDog/datadog-lambda-go/assets/611629/0e2a1fe2-612a-4c5a-8795-7e88b3f14201">
With this addition the error message is retained:
<img width="964" alt="image" src="https://github.com/DataDog/datadog-lambda-go/assets/611629/a8d371a3-b753-43c0-bdaf-5a83796113bc">

### Testing Guidelines

Sabotaged a lambda behind API gateway to reproduce the issue reliably, and then cloned the code, used a replace directive to import the local patched version, deployed and repeated the test (see the attached screenshot). There weren't any unit tests with coverage on the existing case so I did not add any unit testing.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
