### PR TITLE
Add possibility to extend tracer options

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -18,12 +18,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-lambda-go/lambda"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
 	"github.com/DataDog/datadog-lambda-go/internal/extension"
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 	"github.com/DataDog/datadog-lambda-go/internal/metrics"
 	"github.com/DataDog/datadog-lambda-go/internal/trace"
 	"github.com/DataDog/datadog-lambda-go/internal/wrapper"
-	"github.com/aws/aws-lambda-go/lambda"
 )
 
 type (
@@ -71,6 +73,8 @@ type (
 		// TraceContextExtractor is the function that extracts a root/parent trace context from the Lambda event body.
 		// See trace.DefaultTraceExtractor for an example.
 		TraceContextExtractor trace.ContextExtractor
+		// TracerOptions are additional options passed to the tracer.
+		TracerOptions []tracer.StartOption
 	}
 )
 
@@ -214,6 +218,7 @@ func (cfg *Config) toTraceConfig() trace.Config {
 		traceConfig.DDTraceEnabled = cfg.DDTraceEnabled
 		traceConfig.MergeXrayTraces = cfg.MergeXrayTraces
 		traceConfig.TraceContextExtractor = cfg.TraceContextExtractor
+		traceConfig.TracerOptions = cfg.TracerOptions
 	}
 
 	if traceConfig.TraceContextExtractor == nil {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adding a possibility to extend the tracer options.

### Motivation

We'd like to be able to extend the tracer with a couple of custom options.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [x] This PR collects user input/sensitive content into Datadog
