### PR TITLE
feat: DD_LAMBDA_FIPS_MODE handling for metrics

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -345,6 +345,8 @@ func (cfg *Config) calculateFipsMode() bool {
 	if fipsModeEnv != "" {
 		if parsedFipsMode, err := strconv.ParseBool(fipsModeEnv); err == nil {
 			fipsMode = parsedFipsMode
+		} else {
+			logger.Debug(fmt.Sprintf("could not parse %s: %s", fipsModeEnv, err))
 		}
 	}
 

--- a/ddlambda.go
+++ b/ddlambda.go
@@ -70,6 +70,8 @@ type (
 		// the counter will get totally reset after CircuitBreakerInterval
 		// default: 4
 		CircuitBreakerTotalFailures uint32
+		// FIPSMode enables FIPS mode. Defaults to true in GovCloud regions and false elsewhere.
+		FIPSMode *bool
 		// TraceContextExtractor is the function that extracts a root/parent trace context from the Lambda event body.
 		// See trace.DefaultTraceExtractor for an example.
 		TraceContextExtractor trace.ContextExtractor
@@ -97,6 +99,9 @@ const (
 	UniversalInstrumentation = "DD_UNIVERSAL_INSTRUMENTATION"
 	// Initialize otel tracer provider if enabled
 	OtelTracerEnabled = "DD_TRACE_OTEL_ENABLED"
+	// FIPSModeEnvVar is the environment variable that determines whether to enable FIPS mode.
+	// Defaults to true in GovCloud regions and false otherwise.
+	FIPSModeEnvVar = "DD_LAMBDA_FIPS_MODE"
 
 	// DefaultSite to send API messages to.
 	DefaultSite = "datadoghq.com"
@@ -268,6 +273,7 @@ func (cfg *Config) toMetricsConfig(isExtensionRunning bool) metrics.Config {
 
 	mc := metrics.Config{
 		ShouldRetryOnFailure: false,
+		FIPSMode:             cfg.calculateFipsMode(),
 	}
 
 	if cfg != nil {
@@ -323,6 +329,34 @@ func (cfg *Config) toMetricsConfig(isExtensionRunning bool) metrics.Config {
 	}
 
 	return mc
+}
+
+func (cfg *Config) calculateFipsMode() bool {
+	if cfg != nil && cfg.FIPSMode != nil {
+		return *cfg.FIPSMode
+	}
+
+	region := os.Getenv("AWS_REGION")
+	isGovCloud := strings.HasPrefix(region, "us-gov-")
+
+	fipsMode := isGovCloud
+
+	fipsModeEnv := os.Getenv(FIPSModeEnvVar)
+	if fipsModeEnv != "" {
+		if parsedFipsMode, err := strconv.ParseBool(fipsModeEnv); err == nil {
+			fipsMode = parsedFipsMode
+		}
+	}
+
+	if fipsMode || isGovCloud {
+		if fipsMode {
+			logger.Debug("Go Lambda Layer FIPS mode enabled")
+		} else {
+			logger.Debug("Go Lambda Layer FIPS mode disabled")
+		}
+	}
+
+	return fipsMode
 }
 
 // setupAppSec checks if DD_SERVERLESS_APPSEC_ENABLED is set (to true) and when that

--- a/internal/metrics/kms_decrypter.go
+++ b/internal/metrics/kms_decrypter.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"os"
-	"strings"
 
 	"github.com/DataDog/datadog-lambda-go/internal/logger"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -38,19 +37,15 @@ type (
 // functionNameEnvVar is the environment variable that stores the Lambda function name
 const functionNameEnvVar string = "AWS_LAMBDA_FUNCTION_NAME"
 
-// regionEnvVar is the environment variable that stores the current region
-const regionEnvVar string = "AWS_REGION"
-
 // encryptionContextKey is the key added to the encryption context by the Lambda console UI
 const encryptionContextKey string = "LambdaFunctionName"
 
 // MakeKMSDecrypter creates a new decrypter which uses the AWS KMS service to decrypt variables
-func MakeKMSDecrypter() Decrypter {
-	region := os.Getenv(regionEnvVar)
+func MakeKMSDecrypter(fipsMode bool) Decrypter {
 	fipsEndpoint := aws.FIPSEndpointStateUnset
-	if strings.HasPrefix(region, "us-gov-") {
+	if fipsMode {
 		fipsEndpoint = aws.FIPSEndpointStateEnabled
-		logger.Debug("GovCloud region detected. Using FIPS endpoint for KMS decryption.")
+		logger.Debug("Using FIPS endpoint for KMS decryption.")
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithUseFIPSEndpoint(fipsEndpoint))


### PR DESCRIPTION
### What does this PR do?

Correctly handles the `DD_LAMBDA_FIPS_MODE` control, same as we do in the python and js layers.

We no longer support direct Datadog API metric submission when `DD_LAMBDA_FIPS_MODE` is enabled. This setting is enabled by default in govcloud. Various mechanisms are provided to override this configuration value.

Please note that we did not previously actually send metrics with timestamps to the extension. Metrics with timestamps get turned into metrics with timestamp=now. This is still the behavior after this change.

### Testing Guidelines

Added some unit tests. Will also deploy to self-monitoring.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
