### PR TITLE
Fix comment for OTEL env var reading condition

### DIFF
--- a/ddlambda.go
+++ b/ddlambda.go
@@ -232,7 +232,7 @@ func (cfg *Config) toTraceConfig() trace.Config {
 
 	if tracingEnabled, err := strconv.ParseBool(os.Getenv(DatadogTraceEnabledEnvVar)); err == nil {
 		traceConfig.DDTraceEnabled = tracingEnabled
-		// Only read the OTEL env var if DD tracing is disabled
+		// Only read the OTEL env var if DD tracing is enabled
 		if tracingEnabled {
 			if otelTracerEnabled, err := strconv.ParseBool(os.Getenv(OtelTracerEnabled)); err == nil {
 				traceConfig.OtelTracerEnabled = otelTracerEnabled


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix comment for OTEL env var reading condition.

### Motivation

While reading the code to check the configuration values of datadog-lambda-go, I noticed that the comment and the implementation are incorrect.

### Testing Guidelines

Code reading (because this PR only changes the comment).

When reading the `HandlerStarted` function, I noticed that if `l.ddTraceEnabled` is false, the function returns early, while if it is true, the process continues and further actions are taken depending on the condition of `l.otelTracerEnabled`. In other words, when Datadog Trace is enabled, OpenTelemetry Trace is also enabled. This shows that the comment is incorrect and the implementation is correct. 

### Additional Notes

The comment was inserted by:

- https://github.com/DataDog/datadog-lambda-go/pull/159

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
