### PR TITLE
add x-datadog-origin to TraceContext

### DIFF
--- a/internal/trace/constants.go
+++ b/internal/trace/constants.go
@@ -12,6 +12,7 @@ const (
 	traceIDHeader          = "x-datadog-trace-id"
 	parentIDHeader         = "x-datadog-parent-id"
 	samplingPriorityHeader = "x-datadog-sampling-priority"
+	originHeader           = "x-datadog-origin"
 )
 
 const (

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -163,6 +163,9 @@ func getTraceContext(ctx context.Context, headers map[string]string) (TraceConte
 	tc[samplingPriorityHeader] = samplingPriority
 	tc[traceIDHeader] = traceID
 	tc[parentIDHeader] = parentID
+	if origin, ok := headers[originHeader]; ok {
+		tc[originHeader] = origin
+	}
 
 	return tc, true
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds the  x-datadog-origin header to the TraceContext so that traces can be linked to synthetic tests

### Motivation

Traces were not linked to synthetic tests

### Testing Guidelines

In local fork

### Additional Notes

partly fixes #189 

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog


The program was tested solely for our own use cases, which might differ from yours.

Jochen Mehlhorn <jochen.mehlhorn@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH

[Provider Information](https://github.com/Daimler/daimler-foss/blob/master/PROVIDER_INFORMATION.md)