### PR TITLE
Include MultiValueHeaders in DefaultTraceExtractor

### DIFF
--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -27,7 +27,8 @@ import (
 
 type (
 	eventWithHeaders struct {
-		Headers map[string]string `json:"headers"`
+		Headers           map[string]string   `json:"headers"`
+		MultiValueHeaders map[string][]string `json:"multiValueHeaders"`
 	}
 
 	// TraceContext is map of headers containing a Datadog trace context.
@@ -183,6 +184,11 @@ func getHeadersFromEventHeaders(ctx context.Context, ev json.RawMessage) map[str
 	lowercaseHeaders := map[string]string{}
 	for k, v := range eh.Headers {
 		lowercaseHeaders[strings.ToLower(k)] = v
+	}
+	for k, v := range eh.MultiValueHeaders {
+		if len(v) > 0 {
+			lowercaseHeaders[strings.ToLower(k)] = v[0]
+		}
 	}
 
 	return lowercaseHeaders


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR merges MultiValueHeader fields with the normal Header fields in the DefaultTraceExtractor

### Motivation

current ddlambda tries to read headers from `headers` while in our case they are passed as `multiValueHeaders`

### Testing Guidelines

local fork

### Additional Notes

partly fixes #189 (in combination with PR #201)

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
