### PR TITLE
fix: stop the tracer after each invocation. Disable telemetry

### DIFF
--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -97,7 +97,7 @@ func MakeListener(config Config, extensionManager *extension.ExtensionManager) L
 	// Agent instead of using this "discovery" implementation.
 	if extensionManager.IsExtensionRunning() {
 		var err error
-		if statsdClient, err = statsd.New("127.0.0.1:8125"); err != nil {
+		if statsdClient, err = statsd.New("127.0.0.1:8125", statsd.WithoutTelemetry()); err != nil {
 			statsdClient = nil // force nil if an error occurred during statsd client init
 		}
 	}

--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -125,6 +125,7 @@ func (l *Listener) HandlerFinished(ctx context.Context, err error) {
 		}
 	}
 
+	tracer.Stop()
 	tracer.Flush()
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. Stops the tracer after each invocation
2. Disables instrumentation telemetry from statsd client

### Motivation
Limits additional CPU and network overhead which can cause issues for small, high-throughput functions.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
