### PR TITLE
Revert calling tracer.Stop after each invocation.

### DIFF
--- a/internal/trace/listener.go
+++ b/internal/trace/listener.go
@@ -125,7 +125,6 @@ func (l *Listener) HandlerFinished(ctx context.Context, err error) {
 		}
 	}
 
-	tracer.Stop()
 	tracer.Flush()
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-go/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Reverts the addition of `tracer.Stop` to the end of each invocation.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

Nightly e2e tests are failing. We are seeing no golang traces at all, except when `cold_start=true`.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
