### PR TITLE
Use short-lived Datadog credentials in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -68,10 +71,16 @@ jobs:
         working-directory: tests/integration_tests/
         run: yarn install
 
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: datadog-lambda-go
+
       - name: Run tests
         env:
           BUILD_LAYERS: true
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         working-directory: tests/integration_tests/


### PR DESCRIPTION
### dd-trace-go PR

N/A. This change only updates this repository's GitHub Actions authentication and has no corresponding `dd-trace-go` source change.

### What does this PR do?

Replaces the long-lived `DD_API_KEY` GitHub Actions secret used by integration tests with a short-lived API key from `DataDog/dd-sts-action`.

The integration-test job receives GitHub's OIDC token permission, exchanges it against the `datadog-lambda-go` policy, and continues exposing the result through the existing `DD_API_KEY` environment variable.

### Motivation

Migrate CI away from a long-lived Datadog API key as part of the SDLC Security credential migration initiative.

### Testing Guidelines

- `go test ./...`: 133 passed, 0 failed
- `actionlint .github/workflows/build.yml`
- Confirmed the pinned action commit is the signed target of `v1.0.0`
- Confirmed no workflow references `secrets.DD_API_KEY`

### Additional Notes

Depends on https://github.com/ddoghq/dd-source/pull/75857, which supersedes the original policy attempt in https://github.com/ddoghq/dd-source/pull/26738. The policy must merge and deploy before this workflow change is merged.

The existing `DD_API_KEY` repository secret will remain available until this workflow succeeds on `main`. Removing that secret is a separate post-deployment operation.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Checklist

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
